### PR TITLE
Implementation Plan: Add Solver Metadata to Eigensolver Fixtures

### DIFF
--- a/tests/generate_fixtures.py
+++ b/tests/generate_fixtures.py
@@ -246,6 +246,8 @@ def generate_comp_d_eigensolver(
         eigenvalues, eigenvectors = scipy.sparse.linalg.eigsh(
             L, k=k, which="SM", ncv=ncv, tol=1e-4, v0=v0, maxiter=n * 5
         )
+        solver_name = b"eigsh"
+        converged = True
     except scipy.sparse.linalg.ArpackNoConvergence:
         # Dense fallback for graphs with degenerate near-zero eigenvalues
         # (e.g. disconnected graphs where #components >= k).
@@ -258,6 +260,8 @@ def generate_comp_d_eigensolver(
         all_eigenvalues, all_eigenvectors = np.linalg.eigh(L_dense)
         eigenvalues = all_eigenvalues[:k]
         eigenvectors = all_eigenvectors[:, :k]
+        solver_name = b"eigh"
+        converged = False
 
     eigenvalues = np.maximum(eigenvalues, 0.0)
 
@@ -275,12 +279,17 @@ def generate_comp_d_eigensolver(
             file=sys.stderr,
         )
 
+    eigenvalue_gaps = np.diff(eigenvalues)  # shape (k-1,), dtype float64
+
     np.savez(
         outdir / "comp_d_eigensolver",
         eigenvalues=eigenvalues,
         eigenvectors=eigenvectors,
         residuals=residuals,
         k=np.int32(k),
+        solver_name=np.bytes_(solver_name),
+        converged=np.bool_(converged),
+        eigenvalue_gaps=eigenvalue_gaps,
     )
     return eigenvalues, eigenvectors
 

--- a/tests/test_fixture_constraints.py
+++ b/tests/test_fixture_constraints.py
@@ -138,6 +138,103 @@ def test_blobs_connected_2000_min_n(comp_d_e_f_outdir):
     assert int(d["n_samples"]) >= 2000
 
 
+# ── Solver metadata (REQ-META-001/002/003) ────────────────────────────────────
+
+# --- REQ-META-001: solver_name ---
+
+@pytest.mark.parametrize("name", DATASETS)
+def test_comp_d_solver_name_present(name, comp_d_e_f_outdir):
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    assert "solver_name" in d.files
+
+@pytest.mark.parametrize("name", DATASETS)
+def test_comp_d_solver_name_value(name, comp_d_e_f_outdir):
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    val = d["solver_name"].item()
+    assert val in {b"eigsh", b"eigh"}, f"unexpected solver_name: {val!r}"
+
+# --- REQ-META-002: converged ---
+
+@pytest.mark.parametrize("name", DATASETS)
+def test_comp_d_converged_present(name, comp_d_e_f_outdir):
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    assert "converged" in d.files
+
+@pytest.mark.parametrize("name", DATASETS)
+def test_comp_d_converged_dtype(name, comp_d_e_f_outdir):
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    assert d["converged"].dtype == np.bool_, (
+        f"converged dtype {d['converged'].dtype!r} is not bool"
+    )
+
+@pytest.mark.parametrize("name", DATASETS)
+def test_comp_d_metadata_consistency(name, comp_d_e_f_outdir):
+    """converged must be True iff solver_name is b'eigsh'."""
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    converged = d["converged"].item()
+    solver = d["solver_name"].item()
+    assert converged == (solver == b"eigsh"), (
+        f"converged={converged} inconsistent with solver_name={solver!r}"
+    )
+
+# --- REQ-META-003: eigenvalue_gaps ---
+
+@pytest.mark.parametrize("name", DATASETS)
+def test_comp_d_eigenvalue_gaps_present(name, comp_d_e_f_outdir):
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    assert "eigenvalue_gaps" in d.files
+
+@pytest.mark.parametrize("name", DATASETS)
+def test_comp_d_eigenvalue_gaps_dtype_shape(name, comp_d_e_f_outdir):
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    gaps = d["eigenvalue_gaps"]
+    k = int(d["k"])
+    assert gaps.dtype == np.float64, f"eigenvalue_gaps dtype {gaps.dtype!r} != float64"
+    assert gaps.shape == (k - 1,), f"eigenvalue_gaps shape {gaps.shape} != ({k-1},)"
+
+@pytest.mark.parametrize("name", DATASETS)
+def test_comp_d_eigenvalue_gaps_match_diff(name, comp_d_e_f_outdir):
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    assert np.allclose(d["eigenvalue_gaps"], np.diff(d["eigenvalues"]), atol=1e-15)
+
+@pytest.mark.parametrize("name", DATASETS)
+def test_comp_d_eigenvalue_gaps_nonneg(name, comp_d_e_f_outdir):
+    """Gaps must be >= 0 because eigenvalues are sorted ascending."""
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    assert np.all(d["eigenvalue_gaps"] >= -1e-15), (
+        f"negative gap found: {d['eigenvalue_gaps'].min():.2e}"
+    )
+
+# --- REQ-VER-003: comparison method reporting ---
+
+@pytest.mark.parametrize("name", DATASETS)
+def test_comp_d_e_gap_aware_comparison_reports_method(name, comp_d_e_f_outdir):
+    """Gap-aware comparison must report the method used for each column/cluster."""
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from verify_fixtures import _compare_eigenvectors_gap_aware
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    e = load(comp_d_e_f_outdir, name, "comp_e_selection.npz")
+    order = e["order"].tolist()
+    V = d["eigenvectors"]
+    gaps = d["eigenvalue_gaps"]
+    # Compare the embedding against the eigenvectors from which it was selected
+    # (comp_e selects a subset; we verify those selected columns only)
+    selected_V = V[:, order]
+    selected_gaps = np.array([
+        gaps[i] for i in order[:-1]  # gaps between selected columns
+    ]) if len(order) > 1 else np.array([])
+    errors, method_log = _compare_eigenvectors_gap_aware(
+        selected_V, e["embedding"], selected_gaps
+    )
+    assert errors == [], f"Eigenvector comparison failed:\n" + "\n".join(errors)
+    assert len(method_log) > 0, "method_log must report which comparison was used"
+    for entry in method_log:
+        assert "sign-flip" in entry or "subspace" in entry, (
+            f"method_log entry does not name a comparison method: {entry!r}"
+        )
+
+
 # ── Byte-identical repro ──────────────────────────────────────────────────────
 
 def test_byte_identical_reruns(tmp_path):

--- a/tests/verify_fixtures.py
+++ b/tests/verify_fixtures.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import scipy.linalg
 import scipy.sparse
 
 
@@ -220,7 +221,116 @@ def check_comp_d(d: Any) -> list[str]:
     if not np.allclose(VTV, np.eye(VTV.shape[0]), atol=1e-10):
         off_diag = np.abs(VTV - np.eye(VTV.shape[0])).max()
         errors.append(f"eigenvectors not orthonormal (max_off_diag={off_diag:.2e})")
+
+    # REQ-META-001: solver_name
+    if "solver_name" not in d.files:
+        errors.append("missing key 'solver_name'")
+    else:
+        val = d["solver_name"].item()
+        if val not in {b"eigsh", b"eigh"}:
+            errors.append(f"solver_name {val!r} not in {{b'eigsh', b'eigh'}}")
+
+    # REQ-META-002: converged
+    if "converged" not in d.files:
+        errors.append("missing key 'converged'")
+    else:
+        if d["converged"].dtype != np.bool_:
+            errors.append(f"converged dtype {d['converged'].dtype!r} != bool")
+        if "solver_name" in d.files:
+            converged = d["converged"].item()
+            solver = d["solver_name"].item()
+            if converged != (solver == b"eigsh"):
+                errors.append(
+                    f"converged={converged} inconsistent with solver_name={solver!r}"
+                )
+
+    # REQ-META-003: eigenvalue_gaps
+    if "eigenvalue_gaps" not in d.files:
+        errors.append("missing key 'eigenvalue_gaps'")
+    else:
+        gaps = d["eigenvalue_gaps"]
+        if gaps.dtype != np.float64:
+            errors.append(f"eigenvalue_gaps dtype {gaps.dtype!r} != float64")
+        if gaps.shape != (k - 1,):
+            errors.append(f"eigenvalue_gaps shape {gaps.shape} != ({k-1},)")
+        elif not np.allclose(gaps, np.diff(lam), atol=1e-15):
+            errors.append("eigenvalue_gaps does not match np.diff(eigenvalues)")
+
     return errors
+
+
+def _compare_eigenvectors_gap_aware(
+    V_ref: np.ndarray,
+    V_test: np.ndarray,
+    gaps: np.ndarray,
+    gap_threshold: float = 1e-6,
+    atol: float = 1e-14,
+) -> tuple[list[str], list[str]]:
+    """Compare two eigenvector matrices using gap-dependent strategy.
+
+    Args:
+        V_ref: Reference eigenvectors, shape (n, m).
+        V_test: Tested eigenvectors, shape (n, m).
+        gaps: Consecutive eigenvalue differences, shape (m-1,).
+               gaps[i] = lambda[i+1] - lambda[i].
+        gap_threshold: Minimum gap to treat eigenvectors as well-separated.
+        atol: Absolute tolerance for sign-flip comparison.
+
+    Returns:
+        (errors, method_log): errors is a list of failure strings (empty = pass);
+        method_log is a list of strings naming the comparison method per
+        column/cluster (REQ-VER-003).
+    """
+    errors: list[str] = []
+    method_log: list[str] = []
+    m = V_ref.shape[1]
+    if m == 0:
+        return errors, method_log
+
+    # Identify cluster boundaries.  A new cluster starts at column i+1 when
+    # gaps[i] >= gap_threshold (well-separated from i).
+    # gaps has shape (m-1,); column 0 always starts a cluster.
+    cluster_start = 0
+    for i in range(m):
+        at_last = (i == m - 1)
+        gap_after = gaps[i] if i < len(gaps) else gap_threshold  # sentinel
+        end_of_cluster = at_last or gap_after >= gap_threshold
+
+        if end_of_cluster:
+            cluster_end = i + 1  # exclusive
+            cols = slice(cluster_start, cluster_end)
+
+            if cluster_end - cluster_start == 1:
+                # REQ-VER-001: well-separated — per-eigenvector sign-flip
+                col = cluster_start
+                v_ref = V_ref[:, col]
+                v_tst = V_test[:, col]
+                if np.dot(v_ref, v_tst) < 0:
+                    v_tst = -v_tst
+                if not np.allclose(v_ref, v_tst, atol=atol):
+                    errors.append(
+                        f"column {col}: sign-flip comparison failed "
+                        f"(max_diff={np.abs(v_ref - v_tst).max():.2e})"
+                    )
+                method_log.append(f"col {col}: sign-flip")
+            else:
+                # REQ-VER-002: clustered — subspace angle comparison
+                S1 = V_ref[:, cols]
+                S2 = V_test[:, cols]
+                angles = scipy.linalg.subspace_angles(S1, S2)
+                if not np.allclose(angles, 0.0, atol=atol):
+                    errors.append(
+                        f"cols {cluster_start}–{cluster_end-1}: subspace comparison "
+                        f"failed (max_angle={angles.max():.2e})"
+                    )
+                method_log.append(
+                    f"cols {cluster_start}–{cluster_end-1}: subspace "
+                    f"(cluster size {cluster_end - cluster_start})"
+                )
+
+            cluster_start = cluster_end
+
+    return errors, method_log
 
 
 def check_comp_e(d: Any, d_d: Any, n: int, dim: int) -> list[str]:
@@ -236,12 +346,22 @@ def check_comp_e(d: Any, d_d: Any, n: int, dim: int) -> list[str]:
     if trivial_col in order.tolist():
         errors.append(f"trivial eigenvector index {trivial_col} included in order")
     # Cross-step: embedding columns must equal eigenvectors[:, order]
+    # Use gap-aware comparison based on eigenvalue gaps from comp_d.
     V = d_d["eigenvectors"]
-    for i, col in enumerate(order.tolist()):
-        if not (np.allclose(emb[:, i], V[:, col], atol=1e-14) or
-                np.allclose(emb[:, i], -V[:, col], atol=1e-14)):
-            errors.append(f"comp_e column {i} != ±comp_d eigenvectors[:, {col}]")
-            break  # one is enough to flag the issue
+    order_list = order.tolist()
+    selected_V = V[:, order_list]
+    all_gaps = d_d["eigenvalue_gaps"] if "eigenvalue_gaps" in d_d.files else np.array([])
+    # Reindex gaps to the selected eigenvector positions.
+    selected_gaps = np.array([
+        all_gaps[order_list[i]] if order_list[i] < len(all_gaps) else 1.0
+        for i in range(len(order_list) - 1)
+    ]) if len(order_list) > 1 else np.array([])
+    cmp_errors, method_log = _compare_eigenvectors_gap_aware(
+        selected_V, emb, selected_gaps
+    )
+    for line in method_log:
+        print(f"  [comp_e cross-check] {line}", flush=True)
+    errors.extend(cmp_errors)
     return errors
 
 


### PR DESCRIPTION
## Summary

Extend `comp_d_eigensolver.npz` with three new fields — `solver_name` (0-d byte string), `converged` (0-d bool), and `eigenvalue_gaps` (f64 array) — recorded at fixture-generation time. Update the verification layer to validate these fields and route eigenvector comparison between per-column sign-flip and subspace-angle strategies based on eigenvalue gap magnitude.

Three files change: `tests/generate_fixtures.py` captures and saves solver metadata; `tests/verify_fixtures.py` validates metadata and adds the `_compare_eigenvectors_gap_aware` helper used in cross-step `check_comp_e`; `tests/test_fixture_constraints.py` adds parametrized tests for all new fields.

## Requirements

### Fixture Metadata (META)

- **REQ-META-001:** The comp_d_eigensolver.npz fixture must record which solver produced the eigenvectors (eigsh or eigh).
- **REQ-META-002:** The comp_d_eigensolver.npz fixture must record whether ARPACK converged successfully or fell back to dense eigh.
- **REQ-META-003:** The comp_d_eigensolver.npz fixture must include eigenvalue gaps (differences between consecutive sorted eigenvalues) as a float64 array.
- **REQ-META-004:** Solver metadata must be stored in formats readable by Rust (0-d byte string for solver name, 0-d bool for convergence, f64 array for gaps).

### Verification (VER)

- **REQ-VER-001:** The verification suite must use per-eigenvector sign-flip comparison for eigenvalues with well-separated gaps (gap >= 1e-6).
- **REQ-VER-002:** The verification suite must use subspace angle comparison (via scipy.linalg.subspace_angles) for eigenvalue clusters with gap < 1e-6.
- **REQ-VER-003:** The verification suite must report which comparison method was used for each eigenvector or cluster.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Inputs ["Inputs"]
        L["Laplacian L<br/>━━━━━━━━━━<br/>CSR f64 (n×n)<br/>from comp_b"]
        DIM["dim parameter<br/>━━━━━━━━━━<br/>k = dim+1<br/>eigenpairs requested"]
    end

    subgraph Gen ["● generate_fixtures.py: generate_comp_d_eigensolver"]
        direction TB
        EIGSH["eigsh(L, k, which='SM')<br/>━━━━━━━━━━<br/>ARPACK sparse solver<br/>solver_name←b'eigsh'<br/>converged←True"]
        EIGH["np.linalg.eigh(L.toarray())<br/>━━━━━━━━━━<br/>Dense fallback<br/>solver_name←b'eigh'<br/>converged←False"]
        META["● Metadata Assembly<br/>━━━━━━━━━━<br/>eigenvalue_gaps←np.diff(λ)<br/>np.bytes_(solver_name)<br/>np.bool_(converged)"]
    end

    subgraph NPZ ["comp_d_eigensolver.npz (Primary Storage)"]
        direction TB
        EXISTING["eigenvalues (f64, k)<br/>eigenvectors (f64, n×k)<br/>residuals (f64, k)<br/>k (int32, 0-d)"]
        NEW["● solver_name (S*, 0-d)<br/>● converged (bool, 0-d)<br/>● eigenvalue_gaps (f64, k-1)"]
    end

    subgraph Consumers ["Downstream Consumers"]
        direction TB
        COMP_E["generate_comp_e_selection<br/>━━━━━━━━━━<br/>Reads eigenvalues + eigenvectors<br/>→ comp_e_selection.npz"]
        CHK_D["● check_comp_d<br/>━━━━━━━━━━<br/>Validates all 7 keys<br/>dtype/shape/value constraints<br/>metadata consistency gate"]
        GAP["● _compare_eigenvectors_gap_aware<br/>━━━━━━━━━━<br/>gap≥1e-6 → sign-flip per col<br/>gap<1e-6 → subspace_angles<br/>Returns (errors, method_log)"]
        CHK_E["● check_comp_e<br/>━━━━━━━━━━<br/>Cross-step: embedding==eigenvectors[:,order]<br/>Uses gap-aware helper"]
        TESTS["● test_fixture_constraints.py<br/>━━━━━━━━━━<br/>Parametrized over 3 datasets<br/>11 new tests for metadata fields"]
    end

    L -->|"sparse CSR"| EIGSH
    L -->|"on ArpackNoConvergence"| EIGH
    DIM -->|"k=dim+1"| EIGSH
    DIM -->|"k=dim+1"| EIGH
    EIGSH -->|"eigenvalues, eigenvectors"| META
    EIGH -->|"eigenvalues[:k], eigenvectors[:,:k]"| META
    META -->|"np.savez()"| EXISTING
    META -->|"np.savez()"| NEW
    EXISTING -->|"load"| COMP_E
    EXISTING -->|"load"| CHK_D
    NEW -->|"load"| CHK_D
    NEW -->|"eigenvalue_gaps"| GAP
    EXISTING -->|"eigenvectors"| GAP
    GAP -->|"called by"| CHK_E
    EXISTING -->|"load"| CHK_E
    NEW -->|"load"| CHK_E
    EXISTING -->|"load"| TESTS
    NEW -->|"load"| TESTS

    class L,DIM cli;
    class EIGSH,EIGH handler;
    class META handler;
    class EXISTING,NEW stateNode;
    class COMP_E output;
    class CHK_D,GAP,CHK_E,TESTS phase;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([START: generate_comp_d_eigensolver])
    DONE([DONE: comp_d_eigensolver.npz saved])
    VERSTART([START: _compare_eigenvectors_gap_aware])
    VEREND([END: return errors, method_log])

    subgraph Dispatch ["● Solver Dispatch (generate_fixtures.py)"]
        direction TB
        EIGSH["eigsh(L, k, which='SM')<br/>━━━━━━━━━━<br/>ARPACK sparse solver<br/>tol=1e-4, maxiter=n×5"]
        CONV{"ArpackNoConvergence<br/>raised?"}
        EIGH["np.linalg.eigh(L.toarray())<br/>━━━━━━━━━━<br/>Dense fallback<br/>slice [:k]"]
        FLAG_OK["solver_name←b'eigsh'<br/>converged←True"]
        FLAG_FB["solver_name←b'eigh'<br/>converged←False"]
    end

    subgraph Assembly ["● Metadata Assembly (generate_fixtures.py)"]
        direction TB
        CLAMP["eigenvalues = np.maximum(λ, 0.0)"]
        RESID["residuals = ||Lv - λv|| / ||v||<br/>━━━━━━━━━━<br/>per eigenpair"]
        GAPS["eigenvalue_gaps = np.diff(eigenvalues)<br/>━━━━━━━━━━<br/>shape (k-1,), dtype f64"]
    end

    subgraph GapCmp ["● _compare_eigenvectors_gap_aware (verify_fixtures.py)"]
        direction TB
        CLLOOP{"next cluster boundary:<br/>at_last OR<br/>gap_after ≥ 1e-6?"}
        CLSIZE{"cluster_end −<br/>cluster_start == 1?"}
        SIGN["Sign-flip comparison<br/>━━━━━━━━━━<br/>if dot(v_ref,v_tst)<0: v_tst=-v_tst<br/>allclose(v_ref, v_tst, atol=1e-14)<br/>method_log ← 'col N: sign-flip'"]
        SUB["Subspace angle comparison<br/>━━━━━━━━━━<br/>scipy.linalg.subspace_angles(S1,S2)<br/>allclose(angles, 0, atol=1e-14)<br/>method_log ← 'cols A–B: subspace'"]
        NEXT["cluster_start = cluster_end<br/>advance to next cluster"]
    end

    START --> EIGSH
    EIGSH --> CONV
    CONV -->|"no exception"| FLAG_OK
    CONV -->|"ArpackNoConvergence"| EIGH
    EIGH --> FLAG_FB
    FLAG_OK --> CLAMP
    FLAG_FB --> CLAMP
    CLAMP --> RESID
    RESID --> GAPS
    GAPS --> DONE

    VERSTART --> CLLOOP
    CLLOOP -->|"yes — end of cluster"| CLSIZE
    CLSIZE -->|"single column"| SIGN
    CLSIZE -->|"multi-column cluster"| SUB
    SIGN --> NEXT
    SUB --> NEXT
    NEXT -->|"more columns remain"| CLLOOP
    NEXT -->|"all columns processed"| VEREND

    class START,DONE,VERSTART,VEREND terminal;
    class EIGSH,EIGH,CLAMP,RESID,GAPS handler;
    class CONV,CLLOOP,CLSIZE stateNode;
    class FLAG_OK,FLAG_FB phase;
    class SIGN,SUB detector;
```

Closes #19

## Implementation Plan

Plan file: `temp/make-plan/add_solver_metadata_plan_2026-03-20_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
