### PR TITLE
Implementation Plan: Fix Test Code Connectivity Assumptions

### DIFF
--- a/tests/test_fixture_constraints.py
+++ b/tests/test_fixture_constraints.py
@@ -3,8 +3,12 @@ import numpy as np
 import pytest
 from pathlib import Path
 
-DATASETS = ["blobs_50", "disconnected_200", "near_dupes_100",
-            "blobs_connected_200", "blobs_connected_2000"]
+CONNECTED_DATASETS = [
+    "moons_200", "circles_300", "near_dupes_100",
+    "blobs_connected_200", "blobs_connected_2000",
+]
+DISCONNECTED_DATASETS = ["blobs_50", "blobs_500", "blobs_5000", "disconnected_200"]
+ALL_DATASETS = CONNECTED_DATASETS + DISCONNECTED_DATASETS
 SCRIPT = Path(__file__).parent / "generate_fixtures.py"
 
 
@@ -20,12 +24,12 @@ def _run(datasets: list[str], outdir: str, extra_args: list[str] | None = None) 
 
 @pytest.fixture(scope="session")
 def comp_d_e_f_outdir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Generate comp_d/e/f artifacts for three representative datasets once per session.
+    """Generate comp_d/e/f artifacts for all datasets once per session.
 
     Note: pytest-xdist (``-n auto``) is not supported; run without ``-n`` flag.
     """
     td = tmp_path_factory.mktemp("comp_d_e_f")
-    _run(DATASETS, str(td))
+    _run(ALL_DATASETS, str(td))
     return td
 
 
@@ -37,38 +41,50 @@ def load(base: Path, name: str, fname: str):
 
 # ── Component D ───────────────────────────────────────────────────────────────
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_eigenvalues_range(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     lam = d["eigenvalues"]
     assert np.all(lam >= -1e-12) and np.all(lam <= 2.0 + 1e-12)
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_eigenvalues_sorted(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     lam = d["eigenvalues"]
     assert np.all(np.diff(lam) >= -1e-12)   # non-decreasing
 
-@pytest.mark.parametrize("name", ["blobs_50", "near_dupes_100",
-                                   "blobs_connected_200", "blobs_connected_2000"])
+@pytest.mark.parametrize("name", CONNECTED_DATASETS)
 def test_comp_d_first_eigenvalue_near_zero_connected(name, comp_d_e_f_outdir):
     """For connected graphs, smallest eigenvalue of normalized Laplacian is 0."""
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     assert d["eigenvalues"][0] < 1e-6
 
-@pytest.mark.parametrize("name", DATASETS)
+
+@pytest.mark.parametrize("name", DISCONNECTED_DATASETS)
+def test_comp_d_n_components_near_zero_eigenvalues(name, comp_d_e_f_outdir):
+    """Disconnected graphs have exactly n_components near-zero eigenvalues."""
+    c = load(comp_d_e_f_outdir, name, "comp_c_components.npz")
+    d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
+    n_components = int(c["n_components"])
+    near_zero = int(np.sum(d["eigenvalues"] < 1e-6))
+    assert near_zero == n_components, (
+        f"{name}: expected {n_components} near-zero eigenvalues (one per component), "
+        f"got {near_zero}"
+    )
+
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_residuals_small(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     assert np.all(d["residuals"] < 1e-3)
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_eigenvectors_orthonormal(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     V = d["eigenvectors"]
     VTV = V.T @ V
     assert np.allclose(VTV, np.eye(VTV.shape[0]), atol=1e-10)
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_k_scalar(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     e = load(comp_d_e_f_outdir, name, "comp_e_selection.npz")
@@ -78,7 +94,7 @@ def test_comp_d_k_scalar(name, comp_d_e_f_outdir):
 
 # ── Component E ───────────────────────────────────────────────────────────────
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_e_order_skips_trivial(name, comp_d_e_f_outdir):
     e = load(comp_d_e_f_outdir, name, "comp_e_selection.npz")
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
@@ -86,7 +102,7 @@ def test_comp_e_order_skips_trivial(name, comp_d_e_f_outdir):
     trivial_col = np.argsort(d["eigenvalues"])[0]
     assert trivial_col not in order
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_e_embedding_shape(name, comp_d_e_f_outdir):
     e = load(comp_d_e_f_outdir, name, "comp_e_selection.npz")
     raw = np.load(comp_d_e_f_outdir / name / "step0_raw_data.npz")
@@ -96,17 +112,17 @@ def test_comp_e_embedding_shape(name, comp_d_e_f_outdir):
 
 # ── Component F ───────────────────────────────────────────────────────────────
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_f_pre_noise_max_abs_10(name, comp_d_e_f_outdir):
     f = load(comp_d_e_f_outdir, name, "comp_f_scaling.npz")
     assert abs(np.abs(f["pre_noise"]).max() - 10.0) < 1e-5   # f32 precision
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_f_final_equals_pre_plus_noise(name, comp_d_e_f_outdir):
     f = load(comp_d_e_f_outdir, name, "comp_f_scaling.npz")
     assert np.allclose(f["final"], f["pre_noise"] + f["noise"], atol=1e-7)
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_f_noise_statistics(name, comp_d_e_f_outdir):
     f = load(comp_d_e_f_outdir, name, "comp_f_scaling.npz")
     noise = f["noise"].astype(np.float64)
@@ -114,7 +130,7 @@ def test_comp_f_noise_statistics(name, comp_d_e_f_outdir):
     assert abs(noise.mean()) < tol
     assert abs(noise.std() - 0.0001) < tol
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_f_dtypes(name, comp_d_e_f_outdir):
     f = load(comp_d_e_f_outdir, name, "comp_f_scaling.npz")
     assert f["pre_noise"].dtype == np.float32
@@ -144,12 +160,12 @@ def test_blobs_connected_2000_min_n(comp_d_e_f_outdir):
 
 # --- REQ-META-001: solver_name ---
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_solver_name_present(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     assert "solver_name" in d.files
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_solver_name_value(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     val = d["solver_name"].item()
@@ -157,19 +173,19 @@ def test_comp_d_solver_name_value(name, comp_d_e_f_outdir):
 
 # --- REQ-META-002: converged ---
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_converged_present(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     assert "converged" in d.files
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_converged_dtype(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     assert d["converged"].dtype == np.bool_, (
         f"converged dtype {d['converged'].dtype!r} is not bool"
     )
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_metadata_consistency(name, comp_d_e_f_outdir):
     """converged must be True iff solver_name is b'eigsh'."""
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
@@ -181,12 +197,12 @@ def test_comp_d_metadata_consistency(name, comp_d_e_f_outdir):
 
 # --- REQ-META-003: eigenvalue_gaps ---
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_eigenvalue_gaps_present(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     assert "eigenvalue_gaps" in d.files
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_eigenvalue_gaps_dtype_shape(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     gaps = d["eigenvalue_gaps"]
@@ -194,12 +210,12 @@ def test_comp_d_eigenvalue_gaps_dtype_shape(name, comp_d_e_f_outdir):
     assert gaps.dtype == np.float64, f"eigenvalue_gaps dtype {gaps.dtype!r} != float64"
     assert gaps.shape == (k - 1,), f"eigenvalue_gaps shape {gaps.shape} != ({k-1},)"
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_eigenvalue_gaps_match_diff(name, comp_d_e_f_outdir):
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
     assert np.allclose(d["eigenvalue_gaps"], np.diff(d["eigenvalues"]), atol=1e-15)
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_eigenvalue_gaps_nonneg(name, comp_d_e_f_outdir):
     """Gaps must be >= 0 because eigenvalues are sorted ascending."""
     d = load(comp_d_e_f_outdir, name, "comp_d_eigensolver.npz")
@@ -209,7 +225,7 @@ def test_comp_d_eigenvalue_gaps_nonneg(name, comp_d_e_f_outdir):
 
 # --- REQ-VER-003: comparison method reporting ---
 
-@pytest.mark.parametrize("name", DATASETS)
+@pytest.mark.parametrize("name", ALL_DATASETS)
 def test_comp_d_e_gap_aware_comparison_reports_method(name, comp_d_e_f_outdir):
     """Gap-aware comparison must report the method used for each column/cluster."""
     import sys

--- a/tests/test_generate_fixtures.py
+++ b/tests/test_generate_fixtures.py
@@ -94,7 +94,7 @@ def test_pipeline_is_deterministic():
                 )
 
 
-def test_all_7_datasets_generate():
+def test_all_9_datasets_generate():
     with tempfile.TemporaryDirectory() as td:
         cmd = [sys.executable, str(SCRIPT), "--output-dir", td]
         result = subprocess.run(cmd, capture_output=True, text=True)
@@ -102,6 +102,7 @@ def test_all_7_datasets_generate():
         expected_datasets = [
             "blobs_50", "blobs_500", "moons_200", "blobs_5000",
             "circles_300", "near_dupes_100", "disconnected_200",
+            "blobs_connected_200", "blobs_connected_2000",
         ]
         for name in expected_datasets:
             for fname in (
@@ -177,14 +178,15 @@ def test_comp_b_laplacian_output(blobs_50_outdir: Path):
     assert eigvals.max() <= 2.0 + 1e-10, f"Eigenvalue above 2: {eigvals.max()}"
 
 
-def test_comp_c_components_connected(blobs_50_outdir: Path):
+def test_comp_c_components_blobs_50_disconnected(blobs_50_outdir: Path):
     d = np.load(blobs_50_outdir / "blobs_50" / "comp_c_components.npz")
     assert set(d.files) >= {"n_components", "labels"}
-    assert int(d["n_components"]) == 1, "blobs_50 must be a single connected component"
+    assert int(d["n_components"]) > 1, (
+        "blobs_50 must be disconnected (multiple components after graph construction)"
+    )
     labels = d["labels"]
     assert labels.dtype == np.int32
     assert labels.shape == (50,)
-    assert (labels == 0).all(), "all nodes in a single component must have label 0"
 
 
 def test_comp_c_components_disconnected(disconnected_200_outdir: Path):
@@ -203,6 +205,7 @@ def test_step3_membership_no_explicit_zeros():
     datasets = [
         "blobs_50", "blobs_500", "moons_200", "blobs_5000",
         "circles_300", "near_dupes_100", "disconnected_200",
+        "blobs_connected_200", "blobs_connected_2000",
     ]
     with tempfile.TemporaryDirectory() as td:
         _run(datasets, td)


### PR DESCRIPTION
## Summary

Three test files contain incorrect or unverified connectivity assumptions in their dataset
parametrization. The primary issue is that `test_fixture_constraints.py` uses a single
mixed `DATASETS` list that conflates connected and disconnected graphs, causing connected-only
tests to include `blobs_50` (a disconnected dataset) and omit verified connected datasets
(`moons_200`, `circles_300`). A required REQ-TEST-003 test is entirely absent. Two tests in
`test_generate_fixtures.py` also have outdated dataset lists and a wrong connectivity assertion
for `blobs_50`.

The fix replaces the mixed list with explicit `CONNECTED_DATASETS` and `DISCONNECTED_DATASETS`
constants, updates all parametrize calls accordingly, adds the missing eigenvalue count test,
and corrects the `blobs_50` connectivity assertion.

## Requirements

### Test Correctness (TEST)

- **REQ-TEST-001:** Connected-graph-specific tests must only be parametrized over datasets verified to have exactly 1 connected component (moons_200, circles_300, near_dupes_100, or new connected datasets from #16).
- **REQ-TEST-002:** Disconnected-graph-specific tests must only be parametrized over datasets verified to have more than 1 connected component (blobs_50, blobs_500, blobs_5000, disconnected_200).
- **REQ-TEST-003:** A test must exist that verifies disconnected graphs have exactly n_components near-zero eigenvalues (one per connected component, value < 1e-6).
- **REQ-TEST-004:** No test comment or docstring may describe a disconnected dataset as "connected".

### Test Coverage (COV)

- **REQ-COV-001:** All test files (test_generate_fixtures.py, test_fixture_constraints.py, test_pipeline_references.py) must be audited for connectivity assumptions and corrected.
- **REQ-COV-002:** All pytest tests must pass after corrections: `micromamba run -p ./envs/spectral-test pytest tests/ -v`.

## Architecture Impact

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([pytest])

    subgraph S1 ["SCENARIO 1 — Connected Eigenvalue Check"]
        direction LR
        S1_CONN["● CONNECTED_DATASETS<br/>━━━━━━━━━━<br/>moons_200, circles_300<br/>near_dupes_100<br/>blobs_connected_200/2000"]
        S1_FIX["● comp_d_e_f_outdir<br/>━━━━━━━━━━<br/>Session fixture<br/>ALL_DATASETS generated"]
        S1_LOAD["comp_d_eigensolver.npz<br/>━━━━━━━━━━<br/>reads eigenvalues"]
        S1_TEST["● test_comp_d_first_<br/>eigenvalue_near_zero_connected<br/>━━━━━━━━━━<br/>asserts eigenvalues[0] < 1e-6"]
    end

    subgraph S2 ["SCENARIO 2 — ★ Disconnected Eigenvalue Count (NEW)"]
        direction LR
        S2_DISC["● DISCONNECTED_DATASETS<br/>━━━━━━━━━━<br/>blobs_50, blobs_500<br/>blobs_5000, disconnected_200"]
        S2_C["comp_c_components.npz<br/>━━━━━━━━━━<br/>reads n_components"]
        S2_D["comp_d_eigensolver.npz<br/>━━━━━━━━━━<br/>reads eigenvalues"]
        S2_TEST["★ test_comp_d_n_components_<br/>near_zero_eigenvalues<br/>━━━━━━━━━━<br/>asserts count(λ < 1e-6)<br/>== n_components"]
    end

    subgraph S3 ["SCENARIO 3 — All-9-Datasets Coverage"]
        direction LR
        S3_GEN["generate_fixtures.py<br/>━━━━━━━━━━<br/>subprocess: 9 datasets"]
        S3_ALL["● test_all_9_datasets_generate<br/>━━━━━━━━━━<br/>was: 7 datasets<br/>now: all 9 verified"]
        S3_ZEROS["● test_step3_membership_<br/>no_explicit_zeros<br/>━━━━━━━━━━<br/>9 datasets checked"]
    end

    subgraph S4 ["SCENARIO 4 — Connectivity Assertion Correctness"]
        direction LR
        S4_BLOB["blobs_50_outdir<br/>━━━━━━━━━━<br/>session fixture<br/>runs generator for blobs_50"]
        S4_COMP["comp_c_components.npz<br/>━━━━━━━━━━<br/>reads n_components, labels"]
        S4_TEST["● test_comp_c_components_<br/>blobs_50_disconnected<br/>━━━━━━━━━━<br/>asserts n_components > 1<br/>(was: == 1)"]
    end

    START --> S1_CONN
    START --> S2_DISC
    START --> S3_GEN
    START --> S4_BLOB

    S1_CONN --> S1_FIX
    S1_FIX --> S1_LOAD
    S1_LOAD --> S1_TEST

    S2_DISC --> S1_FIX
    S1_FIX --> S2_C
    S1_FIX --> S2_D
    S2_C --> S2_TEST
    S2_D --> S2_TEST

    S3_GEN --> S3_ALL
    S3_GEN --> S3_ZEROS

    S4_BLOB --> S4_COMP
    S4_COMP --> S4_TEST

    class S1_CONN,S2_DISC stateNode;
    class S1_FIX,S4_BLOB phase;
    class S1_LOAD,S2_C,S2_D,S4_COMP,S3_GEN handler;
    class S1_TEST,S3_ALL,S3_ZEROS detector;
    class S2_TEST newComponent;
    class S4_TEST detector;
    class START terminal;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Test runner entry point |
| Teal | State | Dataset constant lists (CONNECTED/DISCONNECTED) |
| Purple | Phase | Session fixtures (expensive, amortized) |
| Orange | Handler | NPZ file reads and generator subprocess |
| Red | Detector | Existing tests with corrected parametrization |
| Green | New | ★ New test for disconnected eigenvalue count |

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([pytest collect])

    subgraph DatasetRouting ["● DATASET ROUTING (test_fixture_constraints.py)"]
        direction TB
        CONN_LIST["● CONNECTED_DATASETS<br/>━━━━━━━━━━<br/>moons_200, circles_300<br/>near_dupes_100<br/>blobs_connected_200/2000"]
        DISC_LIST["● DISCONNECTED_DATASETS<br/>━━━━━━━━━━<br/>blobs_50, blobs_500<br/>blobs_5000, disconnected_200"]
        ALL_LIST["● ALL_DATASETS<br/>━━━━━━━━━━<br/>CONNECTED + DISCONNECTED<br/>(for generic tests)"]
    end

    subgraph SessionCache ["SESSION FIXTURE"]
        direction LR
        CACHE{"comp_d_e_f_outdir<br/>━━━━━━━━━━<br/>cached?"}
        GEN["generate_fixtures.py<br/>━━━━━━━━━━<br/>runs ALL_DATASETS<br/>writes .npz to tmpdir"]
        CACHED["tmpdir<br/>━━━━━━━━━━<br/>reuse cached artifacts"]
    end

    subgraph ConstraintDispatch ["● TEST DISPATCH — test_fixture_constraints.py"]
        direction TB
        GENERIC_T["● Generic Tests<br/>━━━━━━━━━━<br/>eigenvalues_range/sorted<br/>residuals, orthonormal<br/>k_scalar, comp_e, comp_f<br/>solver metadata, gap-aware<br/>→ ALL_DATASETS"]
        CONN_T["● test_comp_d_first_<br/>eigenvalue_near_zero_connected<br/>━━━━━━━━━━<br/>asserts eigenvalues[0] < 1e-6<br/>→ CONNECTED_DATASETS only"]
        DISC_T["★ test_comp_d_n_components_<br/>near_zero_eigenvalues<br/>━━━━━━━━━━<br/>asserts count(λ<1e-6)==n_components<br/>→ DISCONNECTED_DATASETS only"]
    end

    subgraph GenFixDispatch ["● TEST DISPATCH — test_generate_fixtures.py"]
        direction TB
        ALL9_T["● test_all_9_datasets_generate<br/>━━━━━━━━━━<br/>subprocess: no --datasets flag<br/>checks 9 dirs × 9 step files"]
        ZEROS_T["● test_step3_membership_<br/>no_explicit_zeros<br/>━━━━━━━━━━<br/>9 datasets, no explicit zeros"]
        DISC50_T["● test_comp_c_components_<br/>blobs_50_disconnected<br/>━━━━━━━━━━<br/>asserts n_components > 1"]
    end

    PASS([PASS])
    FAIL([FAIL])

    START --> CONN_LIST
    START --> DISC_LIST
    CONN_LIST --> ALL_LIST
    DISC_LIST --> ALL_LIST

    ALL_LIST --> CACHE
    CACHE -->|"not cached"| GEN
    CACHE -->|"cached"| CACHED
    GEN --> GENERIC_T
    CACHED --> GENERIC_T

    CONN_LIST --> CONN_T
    DISC_LIST --> DISC_T
    ALL_LIST --> GENERIC_T

    GEN --> CONN_T
    GEN --> DISC_T

    START --> ALL9_T
    START --> ZEROS_T
    START --> DISC50_T

    GENERIC_T --> PASS
    CONN_T --> PASS
    DISC_T --> PASS
    ALL9_T --> PASS
    ZEROS_T --> PASS
    DISC50_T --> PASS

    GENERIC_T -->|"assertion fails"| FAIL
    CONN_T -->|"λ₀ ≥ 1e-6"| FAIL
    DISC_T -->|"wrong eigenvalue count"| FAIL
    ALL9_T -->|"missing dataset dir"| FAIL
    DISC50_T -->|"n_components == 1"| FAIL

    class CONN_LIST,DISC_LIST,ALL_LIST stateNode;
    class CACHE stateNode;
    class GEN,CACHED handler;
    class GENERIC_T,CONN_T,ALL9_T,ZEROS_T,DISC50_T detector;
    class DISC_T newComponent;
    class START,PASS,FAIL terminal;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | pytest entry point, PASS, FAIL outcomes |
| Teal | State | Dataset classification lists and cache decision |
| Orange | Handler | Fixture generator and cache retrieval |
| Red | Detector | Existing tests with corrected parametrization |
| Green | New | ★ New disconnected eigenvalue count test |

Closes #20

## Implementation Plan

Plan file: `temp/make-plan/fix_connectivity_assumptions_plan_2026-03-20_080900.md`

## Token Usage Summary

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
