### PR TITLE
Implementation Plan: P2-05 Component B — Normalized Laplacian Construction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ path = "tests/integration/test_comp_e_selection.rs"
 [[test]]
 name = "test_comp_a_degrees"
 path = "tests/integration/test_comp_a_degrees.rs"
+
+[[test]]
+name = "test_comp_b_laplacian"
+path = "tests/integration/test_comp_b_laplacian.rs"

--- a/src/laplacian.rs
+++ b/src/laplacian.rs
@@ -1,5 +1,5 @@
 use ndarray::Array1;
-use sprs::CsMatI;
+use sprs::{CsMatI, TriMat};
 
 /// Computes per-node degree and its element-wise square root from a sparse graph.
 ///
@@ -22,11 +22,43 @@ pub fn compute_degrees(
 }
 
 /// Builds the symmetric normalized Laplacian L = I - D^{-1/2} W D^{-1/2} in f64.
-/// Accepts the fuzzy k-NN graph in f32/u32 format from umap-rs and upcasts.
-pub(crate) fn build_normalized_laplacian(
+///
+/// Accepts the fuzzy k-NN graph in f32/u32 format from umap-rs and upcasts weights
+/// to f64 for numerical stability. `inv_sqrt_deg[i]` must equal `1/sqrt(degree[i])`
+/// for connected nodes and `0.0` for isolated (zero-degree) nodes.
+///
+/// Returns a symmetric CSR matrix of shape `(n, n)` with:
+/// - Diagonal entries exactly 1.0 for all nodes (including isolated ones)
+/// - Off-diagonal entries `L[i,j] = -inv_sqrt_deg[i] * W[i,j] * inv_sqrt_deg[j]`
+pub fn build_normalized_laplacian(
     graph: &CsMatI<f32, u32, usize>,
-) -> (CsMatI<f64, usize>, Array1<f64>) {
-    todo!("build_normalized_laplacian: construct L and return degree vector D")
+    inv_sqrt_deg: &[f64],
+) -> CsMatI<f64, usize> {
+    let n = graph.rows();
+    // Capacity: all off-diagonal nonzeros from W, plus n diagonal entries
+    let mut tri: TriMat<f64> = TriMat::with_capacity((n, n), graph.nnz() + n);
+
+    // Off-diagonal entries: L[i,j] = -inv_sqrt_deg[i] * W[i,j] * inv_sqrt_deg[j]
+    for (row_idx, row_vec) in graph.outer_iterator().enumerate() {
+        for (col_idx, &val) in row_vec.iter() {
+            let col = col_idx as usize;
+            if row_idx != col {
+                tri.add_triplet(
+                    row_idx,
+                    col,
+                    -inv_sqrt_deg[row_idx] * (val as f64) * inv_sqrt_deg[col],
+                );
+            }
+        }
+    }
+
+    // Diagonal entries: L[i,i] = 1.0 for all i
+    // (holds exactly: k-NN graphs have no self-loops, so D^{-1/2} W D^{-1/2} diagonal is 0)
+    for i in 0..n {
+        tri.add_triplet(i, i, 1.0);
+    }
+
+    tri.to_csr()
 }
 
 #[cfg(test)]
@@ -49,5 +81,112 @@ mod tests {
         assert!((degrees[1] - 2.0_f64).abs() < 1e-15);
         assert!((degrees[2] - 0.0_f64).abs() < 1e-15); // isolated node
         assert!((sqrt_deg[2] - 0.0_f64).abs() < 1e-15); // sqrt(0) = 0, not NaN
+    }
+
+    #[test]
+    fn build_laplacian_two_node_complete_graph() {
+        // 2-node graph: edge (0,1) weight 1.0 and edge (1,0) weight 1.0
+        let indptr = vec![0usize, 1, 2];
+        let indices = vec![1u32, 0u32];
+        let data = vec![1.0f32, 1.0f32];
+        let graph = CsMatI::new((2, 2), indptr, indices, data);
+        let inv_sqrt_deg = vec![1.0f64, 1.0f64]; // sqrt_deg = [1.0, 1.0]
+
+        let l = build_normalized_laplacian(&graph, &inv_sqrt_deg);
+
+        // Diagonal
+        assert!((l.get(0, 0).copied().unwrap_or(0.0) - 1.0).abs() < 1e-15);
+        assert!((l.get(1, 1).copied().unwrap_or(0.0) - 1.0).abs() < 1e-15);
+        // Off-diagonal
+        assert!((l.get(0, 1).copied().unwrap_or(0.0) - (-1.0)).abs() < 1e-15);
+        assert!((l.get(1, 0).copied().unwrap_or(0.0) - (-1.0)).abs() < 1e-15);
+    }
+
+    #[test]
+    fn build_laplacian_weighted_edge() {
+        // 2-node graph with weight 4.0 on both edges
+        // sqrt_deg = [2.0, 2.0], inv_sqrt_deg = [0.5, 0.5]
+        let indptr = vec![0usize, 1, 2];
+        let indices = vec![1u32, 0u32];
+        let data = vec![4.0f32, 4.0f32];
+        let graph = CsMatI::new((2, 2), indptr, indices, data);
+        let inv_sqrt_deg = vec![0.5f64, 0.5f64];
+
+        let l = build_normalized_laplacian(&graph, &inv_sqrt_deg);
+
+        // L[0,1] = -0.5 * 4.0 * 0.5 = -1.0
+        assert!((l.get(0, 1).copied().unwrap_or(0.0) - (-1.0)).abs() < 1e-15);
+        assert!((l.get(1, 0).copied().unwrap_or(0.0) - (-1.0)).abs() < 1e-15);
+        // Diagonal must be 1.0
+        assert!((l.get(0, 0).copied().unwrap_or(0.0) - 1.0).abs() < 1e-15);
+        assert!((l.get(1, 1).copied().unwrap_or(0.0) - 1.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn build_laplacian_isolated_node() {
+        // 3-node graph: nodes 0 and 1 connected (weight 1.0), node 2 isolated
+        // inv_sqrt_deg = [1.0, 1.0, 0.0]
+        let indptr = vec![0usize, 1, 2, 2];
+        let indices = vec![1u32, 0u32];
+        let data = vec![1.0f32, 1.0f32];
+        let graph = CsMatI::new((3, 3), indptr, indices, data);
+        let inv_sqrt_deg = vec![1.0f64, 1.0f64, 0.0f64];
+
+        let l = build_normalized_laplacian(&graph, &inv_sqrt_deg);
+
+        // Diagonal is always 1.0 including isolated node
+        assert!((l.get(2, 2).copied().unwrap_or(0.0) - 1.0).abs() < 1e-15);
+        // No off-diagonal entries for row/col 2 (inv_sqrt_deg[2] = 0)
+        assert!((l.get(0, 2).copied().unwrap_or(0.0)).abs() < 1e-15);
+        assert!((l.get(2, 0).copied().unwrap_or(0.0)).abs() < 1e-15);
+        assert!((l.get(1, 2).copied().unwrap_or(0.0)).abs() < 1e-15);
+        assert!((l.get(2, 1).copied().unwrap_or(0.0)).abs() < 1e-15);
+        // Connected edge: L[0,1] = L[1,0] = -1.0
+        assert!((l.get(0, 1).copied().unwrap_or(0.0) - (-1.0)).abs() < 1e-15);
+        assert!((l.get(1, 0).copied().unwrap_or(0.0) - (-1.0)).abs() < 1e-15);
+    }
+
+    #[test]
+    fn build_laplacian_symmetry() {
+        // 4-node path graph (0-1-2-3) with equal weights
+        // Edges: (0,1), (1,0), (1,2), (2,1), (2,3), (3,2)
+        let indptr = vec![0usize, 1, 3, 5, 6];
+        let indices = vec![1u32, 0u32, 2u32, 1u32, 3u32, 2u32];
+        let data = vec![1.0f32; 6];
+        let graph = CsMatI::new((4, 4), indptr, indices, data);
+        // Node 0 and 3 have degree 1, nodes 1 and 2 have degree 2
+        // inv_sqrt_deg[0] = 1/sqrt(1) = 1.0
+        // inv_sqrt_deg[1] = 1/sqrt(2)
+        // inv_sqrt_deg[2] = 1/sqrt(2)
+        // inv_sqrt_deg[3] = 1/sqrt(1) = 1.0
+        let inv_sqrt_deg = vec![
+            1.0f64,
+            1.0 / 2.0f64.sqrt(),
+            1.0 / 2.0f64.sqrt(),
+            1.0f64,
+        ];
+
+        let l = build_normalized_laplacian(&graph, &inv_sqrt_deg);
+
+        // All diagonal entries must be exactly 1.0
+        for i in 0..4 {
+            let d = l.get(i, i).copied().unwrap_or(0.0);
+            assert!(
+                (d - 1.0).abs() < 1e-15,
+                "L[{i},{i}] = {d}, expected 1.0"
+            );
+        }
+
+        // Symmetry: |L[i,j] - L[j,i]| < 1e-15 for all i, j
+        for i in 0..4 {
+            for j in 0..4 {
+                let lij = l.get(i, j).copied().unwrap_or(0.0);
+                let lji = l.get(j, i).copied().unwrap_or(0.0);
+                assert!(
+                    (lij - lji).abs() < 1e-15,
+                    "symmetry violation: L[{i},{j}]={lij}, L[{j},{i}]={lji}"
+                );
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ mod solvers;
 pub use crate::selection::select_eigenvectors;
 #[doc(hidden)]
 pub use crate::laplacian::compute_degrees;
+#[doc(hidden)]
+pub use crate::laplacian::build_normalized_laplacian;
 
 use ndarray::Array2;
 use sprs::CsMatI;

--- a/tests/integration/test_comp_b_laplacian.rs
+++ b/tests/integration/test_comp_b_laplacian.rs
@@ -1,0 +1,74 @@
+#[path = "../common/mod.rs"]
+mod common;
+
+use spectral_init::build_normalized_laplacian;
+
+fn run_comp_b_test(dataset: &str, expected_n: usize) {
+    let base = common::fixture_path(dataset, "");
+
+    // Load inputs
+    let graph = common::load_sparse_csr_f32_u32(&base.join("step5a_pruned.npz"));
+
+    // Load comp_a output for sqrt_deg (already validated by comp_a tests)
+    let sqrt_deg: ndarray::Array1<f64> =
+        common::load_dense(&base.join("comp_a_degrees.npz"), "sqrt_deg");
+    let inv_sqrt_deg: Vec<f64> = sqrt_deg
+        .iter()
+        .map(|&s| if s > 0.0 { 1.0 / s } else { 0.0 })
+        .collect();
+
+    // Call function under test
+    let l = build_normalized_laplacian(&graph, &inv_sqrt_deg);
+
+    assert_eq!(l.rows(), expected_n, "Laplacian rows");
+    assert_eq!(l.cols(), expected_n, "Laplacian cols");
+
+    // Load Python reference
+    let ref_l = common::load_sparse_csr(&base.join("comp_b_laplacian.npz"));
+
+    // Element-wise comparison of all nonzero entries in the reference
+    for (&val, (row, col)) in ref_l.iter() {
+        let got = l.get(row, col).copied().unwrap_or(0.0);
+        assert!(
+            (got - val).abs() < 1e-14,
+            "L[{row},{col}]: got {got}, want {val}, diff {}",
+            (got - val).abs()
+        );
+    }
+
+    // Symmetry: for every nonzero (i,j), L[j,i] must match within 1e-15
+    for (&val, (row, col)) in l.iter() {
+        let sym = l.get(col, row).copied().unwrap_or(0.0);
+        assert!(
+            (val - sym).abs() < 1e-15,
+            "symmetry violation L[{row},{col}]={val}, L[{col},{row}]={sym}"
+        );
+    }
+
+    // Diagonal: all 1.0
+    for i in 0..expected_n {
+        let d = l.get(i, i).copied().unwrap_or(0.0);
+        assert!(
+            (d - 1.0).abs() < 1e-15,
+            "L[{i},{i}] = {d}, expected 1.0"
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_b_laplacian_matches_python_blobs_connected_200() {
+    run_comp_b_test("blobs_connected_200", 200);
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_b_laplacian_matches_python_blobs_connected_2000() {
+    run_comp_b_test("blobs_connected_2000", 2000);
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_b_laplacian_matches_python_disconnected_200() {
+    run_comp_b_test("disconnected_200", 200);
+}


### PR DESCRIPTION
## Summary

Implement `build_normalized_laplacian` in `src/laplacian.rs` to build the symmetric normalized Laplacian `L = I - D^{-1/2} W D^{-1/2}` as a sparse f64 CSR matrix. The existing stub has the wrong signature — it is updated to take `inv_sqrt_deg: &[f64]` from the caller (who already has it from `compute_degrees`) and return just the Laplacian matrix. Four unit tests are added inline and a fixture-gated integration test is added in `tests/integration/test_comp_b_laplacian.rs`.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Layer3 ["LAYER 3 — PUBLIC API"]
        LIBRS["● src/lib.rs<br/>━━━━━━━━━━<br/>spectral_init crate root<br/>Re-exports: build_normalized_laplacian<br/>compute_degrees, select_eigenvectors"]
    end

    subgraph Layer2 ["LAYER 2 — CORE MODULES"]
        LAPLACIAN["● src/laplacian.rs<br/>━━━━━━━━━━<br/>compute_degrees()<br/>build_normalized_laplacian()"]
        COMPONENTS["src/components.rs<br/>━━━━━━━━━━<br/>BFS connected components"]
        SOLVERS["src/solvers/<br/>━━━━━━━━━━<br/>dense / lobpcg / rsvd"]
        OTHER["src/scaling.rs<br/>src/selection.rs<br/>src/operator.rs"]
    end

    subgraph Layer1 ["LAYER 1 — TEST INFRASTRUCTURE"]
        COMMON["tests/common/mod.rs<br/>━━━━━━━━━━<br/>Fixture loaders<br/>load_sparse_csr_f32_u32<br/>load_dense, load_sparse_csr"]
        TESTB["★ tests/integration/<br/>test_comp_b_laplacian.rs<br/>━━━━━━━━━━<br/>3 fixture-gated tests<br/>4 inline unit tests"]
    end

    subgraph Layer0 ["LAYER 0 — EXTERNAL CRATES"]
        SPRS["sprs 0.11<br/>━━━━━━━━━━<br/>CsMatI, TriMat, CSR/CSC"]
        NDARRAY["ndarray 0.17<br/>━━━━━━━━━━<br/>Array1, Array2"]
        FAER["faer 0.24<br/>━━━━━━━━━━<br/>Dense EVD"]
        OTHERS["linfa-linalg / rand<br/>annembed / thiserror<br/>━━━━━━━━━━<br/>LOBPCG, rSVD, RNG"]
        DEVDEPS["ndarray-npy / approx<br/>━━━━━━━━━━<br/>(dev deps only)<br/>npz loading, float asserts"]
    end

    LIBRS -->|"mod + pub use"| LAPLACIAN
    LIBRS -->|"mod"| COMPONENTS
    LIBRS -->|"mod"| SOLVERS
    LIBRS -->|"mod"| OTHER

    LAPLACIAN -->|"use sprs::TriMat<br/>use sprs::CsMatI"| SPRS
    LAPLACIAN -->|"use ndarray::Array1"| NDARRAY
    SOLVERS -->|"faer EVD"| FAER
    SOLVERS -->|"linfa-linalg LOBPCG<br/>annembed rSVD"| OTHERS

    TESTB -->|"spectral_init::<br/>build_normalized_laplacian"| LIBRS
    TESTB -->|"#[path] common fixture loaders"| COMMON
    COMMON -->|"ndarray-npy npz loading"| DEVDEPS

    CARGOCHANGE["● Cargo.toml<br/>━━━━━━━━━━<br/>+ [[test]] test_comp_b_laplacian<br/>path: tests/integration/<br/>test_comp_b_laplacian.rs"]
    CARGOCHANGE -.->|"registers"| TESTB

    class LIBRS cli;
    class LAPLACIAN stateNode;
    class COMPONENTS,SOLVERS,OTHER handler;
    class TESTB newComponent;
    class COMMON output;
    class SPRS,NDARRAY,FAER,OTHERS integration;
    class DEVDEPS phase;
    class CARGOCHANGE stateNode;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Public API | `lib.rs` crate root — module declarations and re-exports |
| Teal | ● Modified Core | `laplacian.rs` — implements `build_normalized_laplacian` (modified) |
| Orange | Core Modules | Other internal modules (unchanged for this PR) |
| Green | ★ New Test | `test_comp_b_laplacian.rs` — new integration test file |
| Dark Teal | Test Common | Shared fixture-loading infrastructure |
| Red | External Crates | Third-party dependencies (`sprs`, `ndarray`, `faer`, etc.) |
| Purple | Dev Deps | Test-only dependencies (`ndarray-npy`, `approx`) |
| Dashed Line | Registration | `Cargo.toml` `[[test]]` entry registering the new test binary |

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    START([START<br/>CsMatI&lt;f32, u32, usize&gt;])

    subgraph PhaseA ["PHASE A — compute_degrees() — existing"]
        direction TB
        ITER_ROWS["iterate outer_iterator()<br/>━━━━━━━━━━<br/>sum row weights → degrees[i]<br/>(f32 → f64 widening)"]
        SQRT["mapv(f64::sqrt)<br/>━━━━━━━━━━<br/>sqrt_deg[i] = √degrees[i]<br/>sqrt(0.0) = 0.0 safe"]
    end

    subgraph PhaseB ["PHASE B — caller: inv_sqrt_deg mapping"]
        GUARD{"sqrt_deg[i] &gt; 0.0?<br/>━━━━━━━━━━<br/>zero-degree guard"}
        INV["inv_sqrt_deg[i] = 1.0 / sqrt_deg[i]"]
        ZERO["inv_sqrt_deg[i] = 0.0<br/>━━━━━━━━━━<br/>isolated node → no contribution"]
    end

    subgraph PhaseC ["● PHASE C — build_normalized_laplacian() — new impl"]
        direction TB
        ALLOC["TriMat::with_capacity(n×n, nnz+n)<br/>━━━━━━━━━━<br/>COO accumulator in f64"]
        OFFDIAG_LOOP["for each row_idx, (col_idx, val)<br/>━━━━━━━━━━<br/>iterate CSR off-diagonal entries"]
        SELFLOOP{"row_idx == col?<br/>━━━━━━━━━━<br/>self-loop skip"}
        ADD_OFFDIAG["tri.add_triplet(i, j, val)<br/>━━━━━━━━━━<br/>-inv_sqrt[i] × W[i,j] × inv_sqrt[j]"]
        DIAG_LOOP["for i in 0..n<br/>━━━━━━━━━━<br/>tri.add_triplet(i, i, 1.0)<br/>diagonal always 1.0"]
        TO_CSR["tri.to_csr()<br/>━━━━━━━━━━<br/>sort indices, deduplicate<br/>COO → CSR"]
    end

    COMPLETE([COMPLETE<br/>CsMatI&lt;f64, usize&gt;<br/>L = I - D⁻¹/² W D⁻¹/²])

    START --> ITER_ROWS
    ITER_ROWS --> SQRT
    SQRT -->|"(degrees, sqrt_deg)"| GUARD
    GUARD -->|"yes: connected node"| INV
    GUARD -->|"no: isolated node"| ZERO
    INV --> ALLOC
    ZERO --> ALLOC
    ALLOC --> OFFDIAG_LOOP
    OFFDIAG_LOOP --> SELFLOOP
    SELFLOOP -->|"yes: skip"| OFFDIAG_LOOP
    SELFLOOP -->|"no: off-diagonal"| ADD_OFFDIAG
    ADD_OFFDIAG --> OFFDIAG_LOOP
    OFFDIAG_LOOP -->|"all rows done"| DIAG_LOOP
    DIAG_LOOP --> TO_CSR
    TO_CSR --> COMPLETE

    class START,COMPLETE terminal;
    class ITER_ROWS,SQRT handler;
    class INV,ZERO phase;
    class ALLOC,ADD_OFFDIAG,DIAG_LOOP newComponent;
    class OFFDIAG_LOOP handler;
    class GUARD,SELFLOOP detector;
    class TO_CSR stateNode;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Input graph and output Laplacian matrix |
| Orange | Handler | CSR row iteration and weight summation (existing) |
| Purple | Phase | Caller-side inv_sqrt_deg mapping and isolated-node guard |
| Green | ● New | New `build_normalized_laplacian` body: COO allocation, triplet addition, diagonal fill |
| Red | Detector | Decision guards: zero-degree check and self-loop skip |
| Teal | State | `tri.to_csr()` format conversion — stable CSR output |

Closes #34

## Implementation Plan

Plan file: `temp/make-plan/p2_05_normalized_laplacian_plan_2026-03-20_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
