### PR TITLE
Fix 4 Failing Pipeline Tests Missing `#[ignore]` Guards

### DIFF
--- a/tests/integration/test_pipeline.rs
+++ b/tests/integration/test_pipeline.rs
@@ -5,6 +5,7 @@ use spectral_init::spectral_init;
 use sprs::CsMatI;
 
 #[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
 fn spectral_init_output_shape_all_connected_datasets() {
     let datasets = [
         ("blobs_50", 50usize),
@@ -34,6 +35,7 @@ fn spectral_init_output_shape_all_connected_datasets() {
 }
 
 #[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
 fn spectral_init_output_close_to_pre_noise_blobs_connected_200() {
     // spectral_init() returns the post-noise output (scale_and_add_noise is its final step,
     // adding Gaussian noise with sigma=0.0001 on coordinates scaled to max 10.0).
@@ -173,6 +175,7 @@ fn spectral_init_synthetic_disconnected_preserves_component_structure() {
 // ── fixture-gated tests (require generated .npz files) ───────────────────────
 
 #[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
 fn spectral_init_disconnected_200_shape_and_finite() {
     let path = common::fixture_path("disconnected_200", "step5a_pruned.npz");
     let graph = common::load_sparse_csr_f32_u32(&path);
@@ -186,6 +189,7 @@ fn spectral_init_disconnected_200_shape_and_finite() {
 }
 
 #[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
 fn spectral_init_blobs_50_produces_valid_embedding() {
     // blobs_50 has 3 tight clusters that may be disconnected in the k-NN graph
     let path = common::fixture_path("blobs_50", "step5a_pruned.npz");


### PR DESCRIPTION
## Summary

Four tests in `tests/integration/test_pipeline.rs` referenced fixture files without `#[ignore]` guards, causing them to panic with "No such file or directory" when `.npz` fixtures have not been generated. This fix adds the standard `#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]` attribute to all four missed tests so that `cargo test` passes with zero failures on a clean checkout.

## Architecture Impact

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    CARGO_TEST([cargo test])
    CARGO_FULL([cargo test -- --include-ignored])
    ALL_PASS([✓ zero failures])

    subgraph Scenario1 ["SCENARIO 1: Clean Checkout (fixed by this PR)"]
        direction TB
        SYNTH["Synthetic Tests<br/>━━━━━━━━━━<br/>spectral_init_single_point<br/>spectral_init_fully_connected_uniform<br/>spectral_init_ten_component_graph<br/>+ 3 others — always run"]
        PIPE["● test_pipeline.rs<br/>━━━━━━━━━━<br/>4 fixture-gated tests<br/>now have #[ignore] guard"]
        SKIP["Skipped (ignored)<br/>━━━━━━━━━━<br/>spectral_init_output_shape_*<br/>spectral_init_output_close_to_*<br/>spectral_init_disconnected_200_*<br/>spectral_init_blobs_50_*"]
    end

    subgraph Scenario2 ["SCENARIO 2: Full Validation (after fixture generation)"]
        direction TB
        GEN["generate_fixtures.py<br/>━━━━━━━━━━<br/>writes .npz to tests/fixtures/"]
        FIXT["tests/fixtures/*.npz<br/>━━━━━━━━━━<br/>blobs_50, blobs_connected_200<br/>disconnected_200, moons_200"]
        RUN_FIX["● test_pipeline.rs<br/>━━━━━━━━━━<br/>4 fixture tests run<br/>loads .npz via ndarray-npy"]
    end

    subgraph Scenario3 ["SCENARIO 3: Core Algorithm (Connected Graph)"]
        direction LR
        API["spectral_init()<br/>━━━━━━━━━━<br/>lib.rs — public API<br/>CsMatI<f32> graph in"]
        COMP["find_components()<br/>━━━━━━━━━━<br/>components.rs<br/>BFS → labels"]
        LAP["build_normalized_laplacian()<br/>━━━━━━━━━━<br/>laplacian.rs<br/>L = I - D^-½ W D^-½"]
        SOLV["solve_eigenproblem()<br/>━━━━━━━━━━<br/>solvers/mod.rs<br/>dense → LOBPCG → rSVD"]
        SEL["select_eigenvectors()<br/>━━━━━━━━━━<br/>drop trivial λ≈0<br/>return next n_components"]
        SCALE["scale_and_add_noise()<br/>━━━━━━━━━━<br/>scaling.rs<br/>max→10, add noise, →f32"]
    end

    CARGO_TEST --> Scenario1
    SYNTH --> ALL_PASS
    PIPE --> SKIP
    SKIP --> ALL_PASS

    GEN --> FIXT
    FIXT --> RUN_FIX
    CARGO_FULL --> Scenario2
    RUN_FIX --> ALL_PASS

    API --> COMP
    COMP -->|"1 component"| LAP
    LAP --> SOLV
    SOLV --> SEL
    SEL --> SCALE

    class CARGO_TEST,CARGO_FULL,ALL_PASS terminal;
    class SYNTH handler;
    class PIPE,RUN_FIX newComponent;
    class SKIP detector;
    class GEN phase;
    class FIXT stateNode;
    class API cli;
    class COMP,LAP,SOLV,SEL handler;
    class SCALE output;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal/Entry | `cargo test` entry points and pass/fail outcomes |
| Orange | Handler | Synthetic tests, algorithm processing components |
| Green (●) | Modified | `test_pipeline.rs` — 4 tests received `#[ignore]` in this PR |
| Red | Guard | Ignored/skipped fixture-gated tests |
| Purple | Phase | Fixture generation script |
| Teal | State | Generated `.npz` fixture files |
| Dark Teal | Output | Scaled f32 embedding output |

Closes #58

## Implementation Plan

Plan file: `temp/make-plan/fix_ignore_guards_plan_2026-03-21_093300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
