### PR TITLE
Add dedicated Component C (Connected Components) integration test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,11 @@ name = "test_comp_b_laplacian"
 path = "tests/integration/test_comp_b_laplacian.rs"
 
 [[test]]
+name = "test_comp_c_components"
+path = "tests/integration/test_comp_c_components.rs"
+required-features = ["testing"]
+
+[[test]]
 name = "test_comp_d_dense_evd"
 path = "tests/integration/test_comp_d_dense_evd.rs"
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -150,6 +150,17 @@ use sprs::CsMatI;
 
 /// Load a scipy-saved CSR matrix with f32 data and u32 column indices.
 /// Python scipy typically stores indices as int32 (i32), which are cast to u32 here.
+/// Convert a label vector to a set-of-sets, permitting label-invariant comparison.
+/// Two label assignments are equivalent iff they produce the same partition.
+pub fn partition_of(labels: &[usize]) -> std::collections::BTreeSet<std::collections::BTreeSet<usize>> {
+    let mut map: std::collections::BTreeMap<usize, std::collections::BTreeSet<usize>> =
+        std::collections::BTreeMap::new();
+    for (node, &label) in labels.iter().enumerate() {
+        map.entry(label).or_default().insert(node);
+    }
+    map.into_values().collect()
+}
+
 pub fn load_sparse_csr_f32_u32(path: &Path) -> CsMatI<f32, u32, usize> {
     let file = std::fs::File::open(path)
         .unwrap_or_else(|e| panic!("cannot open fixture {:?}: {}", path, e));

--- a/tests/integration/test_comp_c_components.rs
+++ b/tests/integration/test_comp_c_components.rs
@@ -1,0 +1,124 @@
+#[path = "../common/mod.rs"]
+mod common;
+
+use ndarray_npy::NpzReader;
+use spectral_init::find_components;
+
+/// Load comp_c_components.npz and compare Rust output against Python reference.
+/// `expected_n_components` is the known ground-truth count for the dataset.
+fn run_comp_c_test(dataset: &str, expected_n_components: usize) {
+    let base = common::fixture_path(dataset, "");
+
+    // Run the function under test
+    let graph = common::load_sparse_csr_f32_u32(&base.join("step5a_pruned.npz"));
+    let (labels, n_components) = find_components(&graph);
+
+    // Load Python reference
+    let ref_path = base.join("comp_c_components.npz");
+    let file = std::fs::File::open(&ref_path)
+        .unwrap_or_else(|e| panic!("dataset {dataset}: cannot open {ref_path:?}: {e}"));
+    let mut npz = NpzReader::new(file)
+        .unwrap_or_else(|e| panic!("dataset {dataset}: NpzReader failed for {ref_path:?}: {e}"));
+
+    let py_n: i32 = npz
+        .by_name::<ndarray::OwnedRepr<i32>, ndarray::Ix0>("n_components")
+        .unwrap_or_else(|e| panic!("dataset {dataset}: n_components key missing: {e}"))
+        .into_scalar();
+    let py_labels_arr: ndarray::Array1<i32> = npz
+        .by_name("labels")
+        .unwrap_or_else(|e| panic!("dataset {dataset}: labels key missing: {e}"));
+    let py_labels: Vec<usize> = py_labels_arr.iter().map(|&x| x as usize).collect();
+
+    assert_eq!(
+        n_components,
+        py_n as usize,
+        "dataset {dataset}: n_components mismatch (rust={n_components}, python={py_n})"
+    );
+    assert_eq!(
+        n_components,
+        expected_n_components,
+        "dataset {dataset}: expected {expected_n_components} components, got {n_components}"
+    );
+    assert_eq!(
+        common::partition_of(&labels),
+        common::partition_of(&py_labels),
+        "dataset {dataset}: label partitioning does not match Python"
+    );
+}
+
+// ── Per-dataset tests ─────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_c_components_matches_python_blobs_50() {
+    run_comp_c_test("blobs_50", 3);
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_c_components_matches_python_blobs_500() {
+    run_comp_c_test("blobs_500", 4);
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_c_components_matches_python_blobs_5000() {
+    run_comp_c_test("blobs_5000", 2);
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_c_components_matches_python_blobs_connected_200() {
+    run_comp_c_test("blobs_connected_200", 1);
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_c_components_matches_python_blobs_connected_2000() {
+    run_comp_c_test("blobs_connected_2000", 1);
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_c_components_matches_python_circles_300() {
+    run_comp_c_test("circles_300", 1);
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_c_components_matches_python_moons_200() {
+    run_comp_c_test("moons_200", 1);
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_c_components_matches_python_near_dupes_100() {
+    run_comp_c_test("near_dupes_100", 1);
+}
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_c_components_matches_python_disconnected_200() {
+    run_comp_c_test("disconnected_200", 4);
+}
+
+// ── All-datasets sweep ────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "requires generated .npz fixtures; run: python tests/generate_fixtures.py"]
+fn comp_c_components_matches_python_all_datasets() {
+    let datasets: &[(&str, usize)] = &[
+        ("blobs_50", 3),
+        ("blobs_500", 4),
+        ("blobs_5000", 2),
+        ("blobs_connected_200", 1),
+        ("blobs_connected_2000", 1),
+        ("circles_300", 1),
+        ("moons_200", 1),
+        ("near_dupes_100", 1),
+        ("disconnected_200", 4),
+    ];
+    for &(dataset, expected) in datasets {
+        run_comp_c_test(dataset, expected);
+    }
+}


### PR DESCRIPTION
## Summary

Create `tests/integration/test_comp_c_components.rs` — a dedicated integration test target that directly exercises the public `find_components()` function against Python-generated `.npz` reference fixtures for all 9 datasets. Extend `tests/common/mod.rs` with the shared `partition_of` helper. Register the new target in `Cargo.toml` with `required-features = ["testing"]` (because `find_components` is only re-exported under the `testing` feature flag).

The existing fixture-gated tests in `src/components.rs` are unit tests in the library's private `#[cfg(test)]` module. They exercise the function in isolation but are not a named integration target and cannot be run independently. This plan promotes that coverage to a proper, isolated integration test binary.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Layer3 ["LAYER 3 — INTEGRATION TEST BINARIES (Cargo.toml [[test]])"]
        direction LR
        COMP_C["★ test_comp_c_components<br/>━━━━━━━━━━<br/>required-features: testing<br/>9 datasets + sweep"]
        COMP_A["● test_comp_a_degrees<br/>━━━━━━━━━━<br/>no required-features<br/>tolerance widened"]
        OTHER["test_comp_b / d / e / f<br/>test_pipeline / e2e / adversarial<br/>━━━━━━━━━━<br/>(unchanged)"]
    end

    subgraph Layer2 ["LAYER 2 — SHARED TEST UTILITIES"]
        COMMON["● tests/common/mod.rs<br/>━━━━━━━━━━<br/>fixture_path()<br/>load_sparse_csr_f32_u32()<br/>★ +partition_of()"]
    end

    subgraph Layer1 ["LAYER 1 — LIBRARY PUBLIC API"]
        LIB["src/lib.rs<br/>━━━━━━━━━━<br/>#[cfg(feature=testing)]<br/>pub find_components()"]
        COMPONENTS["src/components.rs<br/>━━━━━━━━━━<br/>find_components() impl<br/>(BFS connected components)"]
        LIB --> COMPONENTS
    end

    subgraph Layer0 ["LAYER 0 — EXTERNAL CRATES"]
        direction LR
        NPY["ndarray_npy<br/>━━━━━━━━━━<br/>NpzReader"]
        SPRS["sprs<br/>━━━━━━━━━━<br/>CsMatI<f32,u32>"]
        NDARRAY["ndarray<br/>━━━━━━━━━━<br/>Array1/Array2"]
    end

    %% VALID DEPENDENCIES %%
    COMP_C -->|"#[path] mod common"| COMMON
    COMP_C -->|"use spectral_init::find_components"| LIB
    COMP_C -->|"NpzReader (direct)"| NPY
    COMP_A -->|"#[path] mod common"| COMMON
    OTHER -->|"#[path] mod common"| COMMON
    COMMON -->|"CsMatI<f32,u32>"| SPRS
    COMMON -->|"Array1/Array2"| NDARRAY
    COMMON -->|"NpzReader"| NPY
    COMMON -->|"LinearOperator trait"| LIB

    %% CLASS ASSIGNMENTS %%
    class COMP_C newComponent;
    class COMP_A,COMMON detector;
    class OTHER handler;
    class LIB phase;
    class COMPONENTS stateNode;
    class NPY,SPRS,NDARRAY integration;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Green | New (★) | New test binary `test_comp_c_components` |
| Red | Modified (●) | `tests/common/mod.rs` extended with `partition_of`, `test_comp_a_degrees` tolerance fix |
| Orange | Unchanged | Existing integration test binaries |
| Purple | Feature-Gated API | `lib.rs` — `find_components` exposed under `testing` feature |
| Teal | Implementation | `components.rs` — BFS connected components logic |
| Dark Red | External | Third-party crates (`ndarray_npy`, `sprs`, `ndarray`) |

Closes #59

## Implementation Plan

Plan file: `temp/make-plan/add_comp_c_integration_test_plan_2026-03-21_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
