### PR TITLE
Update Implementation Report with Audit Remediation Status

### DIFF
--- a/docs/umap-spectral-initialization-rust-implementation-report.md
+++ b/docs/umap-spectral-initialization-rust-implementation-report.md
@@ -19,7 +19,9 @@
 10. [Fortran Performance Parity & SIMD Optimization](#10-fortran-performance-parity--simd-optimization)
 11. [Mathematical Reference](#11-mathematical-reference)
 12. [Risk Assessment & Mitigations](#12-risk-assessment--mitigations)
-13. [Sources](#13-sources)
+13. [Phase 2 Implementation Completion Status](#13-phase-2-implementation-completion-status)
+14. [Audit Findings & Remediation Status](#14-audit-findings--remediation-status)
+15. [Sources](#15-sources)
 
 ---
 
@@ -1470,12 +1472,15 @@ For typical UMAP: `n=50k`, `k=15 neighbors`, `nnz ~ 750k`, requesting 2–3 eige
 
 ### 12.3 Performance at Scale
 
-| Scale | Strategy | Expected Time |
-|-------|----------|---------------|
-| n < 2k | Dense faer EVD | < 100ms |
-| 2k < n < 100k | LOBPCG | 1-10s |
-| 100k < n < 2M | LOBPCG with preconditioning | 10-60s |
-| n > 2M | Randomized SVD (2I-L trick) | 30-120s |
+| Scale | Strategy | Measured Baseline (ring graph) | Notes |
+|-------|----------|-------------------------------|-------|
+| n = 200 | Dense faer EVD (Level 0) | 396 ns SpMV; 12.6 ms dense EVD standalone; 14.2 ms full pipeline | Exact; cannot fail |
+| n = 2000 | LOBPCG (Level 1) | 223 ms full pipeline; 4.83 µs SpMV; 306 ms LOBPCG standalone | Iterative; may escalate |
+| n = 2000 | Randomized SVD (Level 3) | 286 ms standalone | Different failure modes than LOBPCG |
+| n = 2000 | Laplacian construction | 228 µs | One-time cost |
+| n = 2000 | BFS connected components | 7.24 µs | One-time cost |
+
+> **Note:** Baselines measured on ring graphs (`make_ring_graph(n, 2)`). Real UMAP kNN graphs have non-uniform degree distributions; expect 2–4× slower SpMV in practice. See `benches/README.md` for full details and Phase 3 optimization targets.
 
 ### 12.4 Missing Pieces in the Ecosystem
 
@@ -1488,7 +1493,107 @@ For typical UMAP: `n=50k`, `k=15 neighbors`, `nnz ~ 750k`, requesting 2–3 eige
 
 ---
 
-## 13. Sources
+## 13. Phase 2 Implementation Completion Status
+
+**Status: COMPLETE** (as of 2026-03-21)
+
+All Phase 2 components have been implemented, tested against Python reference fixtures, and merged. Phase 2 produced a fully functional `spectral_init()` public API matching Python UMAP's spectral initialization output within tolerance.
+
+### 13.1 Phase 2 Work Items
+
+| Issue | ID | Title | Status | PR |
+|-------|----|-------|--------|----|
+| [#27](https://github.com/TalonT-Org/spectral-init/issues/27) | P2-01 | Project scaffolding and module structure | ✅ COMPLETE | — |
+| [#28](https://github.com/TalonT-Org/spectral-init/issues/28) | P2-02 | NPZ fixture loading infrastructure for Rust tests | ✅ COMPLETE | — |
+| [#29](https://github.com/TalonT-Org/spectral-init/issues/29) | P2-03 | Component A — Degree vector computation | ✅ COMPLETE | — |
+| [#30](https://github.com/TalonT-Org/spectral-init/issues/30) | P2-04 | Component C — Connected components (BFS) | ✅ COMPLETE | — |
+| [#34](https://github.com/TalonT-Org/spectral-init/issues/34) | P2-05 | Component B — Normalized Laplacian construction | ✅ COMPLETE | — |
+| [#31](https://github.com/TalonT-Org/spectral-init/issues/31) | P2-06 | Component E — Eigenvector selection | ✅ COMPLETE | — |
+| [#32](https://github.com/TalonT-Org/spectral-init/issues/32) | P2-07 | Component F — Coordinate scaling and noise | ✅ COMPLETE | — |
+| [#33](https://github.com/TalonT-Org/spectral-init/issues/33) | P2-08 | LinearOperator trait and SpMV implementation | ✅ COMPLETE | — |
+| [#35](https://github.com/TalonT-Org/spectral-init/issues/35) | P2-09 | Dense EVD solver via faer (Level 0 / Level 4) | ✅ COMPLETE | [#52](https://github.com/TalonT-Org/spectral-init/pull/52) |
+| [#36](https://github.com/TalonT-Org/spectral-init/issues/36) | P2-10 | LOBPCG iterative eigensolver (Level 1–2) | ✅ COMPLETE | [#50](https://github.com/TalonT-Org/spectral-init/pull/50) |
+| [#37](https://github.com/TalonT-Org/spectral-init/issues/37) | P2-11 | Randomized SVD solver via 2I-L trick (Level 3) | ✅ COMPLETE | [#51](https://github.com/TalonT-Org/spectral-init/pull/51) |
+| [#38](https://github.com/TalonT-Org/spectral-init/issues/38) | P2-12 | Solver escalation chain | ✅ COMPLETE | [#53](https://github.com/TalonT-Org/spectral-init/pull/53) |
+| [#39](https://github.com/TalonT-Org/spectral-init/issues/39) | P2-13 | Pipeline integration — spectral_init() public API | ✅ COMPLETE | [#54](https://github.com/TalonT-Org/spectral-init/pull/54) |
+| [#40](https://github.com/TalonT-Org/spectral-init/issues/40) | P2-14 | Component G — Multi-component layout for disconnected graphs | ✅ COMPLETE | [#55](https://github.com/TalonT-Org/spectral-init/pull/55) |
+| [#41](https://github.com/TalonT-Org/spectral-init/issues/41) | P2-15 | End-to-end validation against all fixtures | ✅ COMPLETE | [#56](https://github.com/TalonT-Org/spectral-init/pull/56) |
+
+> Items P2-01 through P2-08 were implemented as part of the initial scaffolding commits without dedicated feature PRs.
+
+### 13.2 Phase 2 Deliverables
+
+| Deliverable | Location |
+|-------------|----------|
+| Public API | `src/lib.rs` → `spectral_init()` |
+| Solver chain | `src/solvers/mod.rs` (Level 0–4) |
+| Dense EVD | `src/solvers/dense.rs` |
+| LOBPCG | `src/solvers/lobpcg.rs` |
+| Randomized SVD | `src/solvers/rsvd.rs` |
+| Normalized Laplacian | `src/laplacian.rs` |
+| Connected components | `src/components.rs` |
+| Multi-component layout | `src/multi_component.rs` |
+| Coordinate scaling | `src/scaling.rs` |
+| Integration tests | `tests/integration/` (9 datasets) |
+| Python fixtures | `tests/fixtures/*.npz` |
+
+---
+
+## 14. Audit Findings & Remediation Status
+
+Following Phase 2 completion, an audit identified 13 findings across correctness, test coverage, code quality, and tooling. **12 of 13 are RESOLVED**; 1 (accuracy report generator) is in progress.
+
+### 14.1 Findings Summary
+
+| # | Issue | Title | Category | Severity | Status | Resolution PR |
+|---|-------|-------|----------|----------|--------|---------------|
+| 1 | [#58](https://github.com/TalonT-Org/spectral-init/issues/58) | Fix 2 failing pipeline tests missing `#[ignore]` guards | Test Quality | High | ✅ RESOLVED | [#76](https://github.com/TalonT-Org/spectral-init/pull/76) |
+| 2 | [#59](https://github.com/TalonT-Org/spectral-init/issues/59) | Add dedicated Component C (connected components) integration test | Test Coverage | High | ✅ RESOLVED | [#82](https://github.com/TalonT-Org/spectral-init/pull/82) |
+| 3 | [#60](https://github.com/TalonT-Org/spectral-init/issues/60) | Inject known trivial eigenvector in LOBPCG initialization | Correctness | High | ✅ RESOLVED | [#79](https://github.com/TalonT-Org/spectral-init/pull/79) |
+| 4 | [#61](https://github.com/TalonT-Org/spectral-init/issues/61) | Add residual quality gates to solver Levels 0, 1, and 2 | Correctness | High | ✅ RESOLVED | [#74](https://github.com/TalonT-Org/spectral-init/pull/74) |
+| 5 | [#62](https://github.com/TalonT-Org/spectral-init/issues/62) | Subtract regularization epsilon from Level 2 eigenvalues | Correctness | High | ✅ RESOLVED | [#75](https://github.com/TalonT-Org/spectral-init/pull/75) |
+| 6 | [#63](https://github.com/TalonT-Org/spectral-init/issues/63) | Wire spmv_csr into CsrOperator or document intentional dead code | Code Quality | Medium | ✅ RESOLVED | [#73](https://github.com/TalonT-Org/spectral-init/pull/73) |
+| 7 | [#64](https://github.com/TalonT-Org/spectral-init/issues/64) | Fix Component E integration test dataset reference | Test Quality | Medium | ✅ RESOLVED | [#83](https://github.com/TalonT-Org/spectral-init/pull/83) |
+| 8 | [#65](https://github.com/TalonT-Org/spectral-init/issues/65) | Expand component integration tests to all 9 datasets | Test Coverage | Medium | ✅ RESOLVED | [#84](https://github.com/TalonT-Org/spectral-init/pull/84) |
+| 9 | [#66](https://github.com/TalonT-Org/spectral-init/issues/66) | Tighten test tolerances to match numerical precision | Test Quality | Medium | ✅ RESOLVED | [#72](https://github.com/TalonT-Org/spectral-init/pull/72) |
+| 10 | [#67](https://github.com/TalonT-Org/spectral-init/issues/67) | Add adversarial synthetic graph test suite for solver escalation | Test Coverage | Medium | ✅ RESOLVED | [#77](https://github.com/TalonT-Org/spectral-init/pull/77) |
+| 11 | [#68](https://github.com/TalonT-Org/spectral-init/issues/68) | Add cargo-nextest with JUnit XML output and CI profile | Tooling | Low | ✅ RESOLVED | [#81](https://github.com/TalonT-Org/spectral-init/pull/81) |
+| 12 | [#70](https://github.com/TalonT-Org/spectral-init/issues/70) | Add criterion benchmark baselines for SpMV, dense EVD, LOBPCG, rSVD | Observability | Low | ✅ RESOLVED | [#78](https://github.com/TalonT-Org/spectral-init/pull/78) |
+| 13 | [#69](https://github.com/TalonT-Org/spectral-init/issues/69) | Add numerical accuracy report generator | Observability | Low | ⏳ IN PROGRESS | — |
+
+### 14.2 Finding Details
+
+**Finding 1 — #58: Missing `#[ignore]` guards on pipeline tests**
+Two tests in `test_pipeline.rs` referenced `blobs_connected_200` fixtures without `#[ignore]` guards, causing `cargo test` to fail unconditionally on clean checkouts. Fixed by adding `#[ignore]` with the standard message, consistent with all other fixture-dependent tests.
+
+**Finding 3 — #60: LOBPCG trivial eigenvector injection**
+LOBPCG was initialized with random vectors, giving the solver no prior knowledge of the trivial eigenvector (eigenvalue = 0). Injecting the known first eigenvector (`sqrt(degree_i)` normalized) significantly improves convergence for near-degenerate spectra and eliminates a class of convergence failures.
+
+**Finding 4 — #61: Solver residual quality gates**
+Levels 0, 1, and 2 returned eigenvectors without checking `||L·v - λ·v|| / ||v||`. Adding residual checks ensures solvers only return results meeting numerical quality thresholds; otherwise they propagate errors to the next escalation level.
+
+**Finding 5 — #62: Level 2 eigenvalue bias**
+Level 2 (LOBPCG + regularization) adds `ε·I` to the Laplacian to separate eigenvalue 0 from near-zero eigenvalues. The returned eigenvalues were not corrected for this shift, producing eigenvalues biased high by `ε`. Fixed by subtracting `REGULARIZATION_EPS` from Level 2 output eigenvalues.
+
+**Finding 13 — #69: Accuracy report generator (IN PROGRESS)**
+No tool exists to generate a structured per-dataset accuracy report showing solver level selected, eigenvalue error, per-eigenvector residuals, subspace alignment (Gram determinant), and tolerance margin. This is needed to validate numerical quality across all 9 datasets in a single pass. Implementation tracked in issue #69.
+
+### 14.3 Accuracy Report (Pending — Issue #69)
+
+Once issue #69 is resolved, an accuracy report will be generated at `target/accuracy-report.md` covering:
+
+- Solver level selected per dataset
+- Eigenvalue accuracy vs Python reference (absolute and relative error)
+- Per-eigenvector residual `||L·v - λ·v|| / ||v||`
+- Pre-noise scaling accuracy vs Python `comp_f_scaling.npz`
+- Subspace alignment (Gram determinant) vs Python eigenvectors
+- Tolerance margin analysis (how close each test is to its threshold)
+
+This appendix will be updated when that report is first generated.
+
+---
+
+## 15. Sources
 
 ### Primary Source Code
 - [umap/spectral.py — lmcinnes/umap](https://github.com/lmcinnes/umap/blob/master/umap/spectral.py)
@@ -1516,4 +1621,4 @@ For typical UMAP: `n=50k`, `k=15 neighbors`, `nnz ~ 750k`, requesting 2–3 eige
 
 ---
 
-*Report generated 2026-03-10 via multi-agent research investigation.*
+*Report originally generated 2026-03-10 via multi-agent research investigation. Last updated 2026-03-21: added Phase 2 completion status (Section 13), audit remediation record (Section 14), and actual performance baselines.*


### PR DESCRIPTION
## Summary

Update `docs/umap-spectral-initialization-rust-implementation-report.md` to serve as the definitive project-status record for Phase 1 + Phase 2. The document currently ends at Section 13 (Sources) with no Phase 2 completion status and no audit findings section. This plan adds two new sections (Phase 2 Completion Status and Audit Findings), incorporates actual benchmark baselines from `benches/README.md`, references the pending accuracy report (issue #69), renumbers Sources to Section 15, and updates the Table of Contents and footer.

Closes #71

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-71-20260321-140952-001707/temp/make-plan/update_impl_report_plan_2026-03-21_140952.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
