### PR TITLE
Implementation Plan: Add Numerical Accuracy Report Generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ndarray16 = { package = "ndarray", version = "0.16" }  # linfa-linalg uses ndarr
 ndarray-npy = "0.10"
 approx = "0.5"
 serde_json = "1"
+humantime = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[test]]
@@ -68,6 +69,11 @@ path = "tests/integration/test_e2e_validation.rs"
 [[test]]
 name = "test_adversarial_graphs"
 path = "tests/integration/test_adversarial_graphs.rs"
+required-features = ["testing"]
+
+[[test]]
+name = "test_accuracy_report"
+path = "tests/integration/test_accuracy_report.rs"
 required-features = ["testing"]
 
 [[bench]]

--- a/tests/integration/test_accuracy_report.rs
+++ b/tests/integration/test_accuracy_report.rs
@@ -1,0 +1,477 @@
+#[path = "../common/mod.rs"]
+mod common;
+
+use ndarray::{Array1, Array2, ArrayView1};
+use spectral_init::{
+    build_normalized_laplacian, compute_degrees, find_components,
+    select_eigenvectors, solve_eigenproblem_pub, spectral_init,
+};
+use std::path::Path;
+
+/// (name, n, is_connected, expected_n_components)
+const DATASETS: &[(&str, usize, bool, usize)] = &[
+    ("blobs_50",              50,   false, 3),
+    ("blobs_500",             500,  false, 4),
+    ("blobs_5000",            5000, false, 2),
+    ("blobs_connected_200",   200,  true,  1),
+    ("blobs_connected_2000",  2000, true,  1),
+    ("circles_300",           300,  true,  1),
+    ("disconnected_200",      200,  false, 4),
+    ("moons_200",             200,  true,  1),
+    ("near_dupes_100",        100,  true,  1),
+];
+
+#[allow(dead_code)]
+struct DatasetMetrics {
+    dataset: String,
+    n: usize,
+    n_components: usize,
+    is_connected: bool,
+    solver_level: Option<u8>,
+    solver_name: &'static str,
+    eigenvalues_rust: Vec<f64>,
+    eigenvalues_ref: Vec<f64>,
+    eigenvalue_abs_errors: Vec<f64>,
+    eigenvalue_rel_errors: Vec<f64>,
+    per_eigenvec_residuals: Vec<f64>,
+    max_residual: f64,
+    subspace_gram_det: Option<f64>,
+    pre_noise_max_err: f64,
+    e2e_max_residual: Option<f64>,
+    component_count_matches: bool,
+}
+
+struct ToleranceMarginEntry {
+    component: String,
+    tolerance: f64,
+    tolerance_type: &'static str,
+    worst_actual: f64,
+    margin_factor: f64,
+}
+
+struct AccuracyReport {
+    generated_at: String,
+    datasets: Vec<DatasetMetrics>,
+    tolerance_margins: Vec<ToleranceMarginEntry>,
+}
+
+fn gram_det_2d(
+    v1: ArrayView1<f64>, v2: ArrayView1<f64>,
+    r1: ArrayView1<f64>, r2: ArrayView1<f64>,
+) -> f64 {
+    let norm = |v: ArrayView1<f64>| v.iter().map(|x| x * x).sum::<f64>().sqrt().max(1e-300);
+    let dot  = |a: ArrayView1<f64>, b: ArrayView1<f64>|
+        a.iter().zip(b.iter()).map(|(x, y)| x * y).sum::<f64>();
+    let n1 = norm(v1); let n2 = norm(v2); let nr1 = norm(r1); let nr2 = norm(r2);
+    let a = dot(r1, v1) / (nr1 * n1);
+    let b = dot(r1, v2) / (nr1 * n2);
+    let c = dot(r2, v1) / (nr2 * n1);
+    let d = dot(r2, v2) / (nr2 * n2);
+    (a * d - b * c).abs()
+}
+
+fn compute_rust_pre_noise(selected: &Array2<f64>) -> Array2<f32> {
+    let max_abs = selected.iter().map(|x| x.abs()).fold(0.0f64, f64::max);
+    if max_abs == 0.0 {
+        return Array2::<f32>::zeros(selected.raw_dim());
+    }
+    let expansion = 10.0 / max_abs;
+    selected.mapv(|v| (v * expansion) as f32)
+}
+
+fn pre_noise_max_err(rust: &Array2<f32>, reference: &Array2<f32>) -> f64 {
+    let mut worst = 0.0f64;
+    for col in 0..rust.ncols() {
+        let r = rust.column(col);
+        let rf = reference.column(col);
+        let err_pos: f64 = r.iter().zip(rf.iter())
+            .map(|(&a, &b)| (a as f64 - b as f64).abs())
+            .fold(0.0f64, f64::max);
+        let err_neg: f64 = r.iter().zip(rf.iter())
+            .map(|(&a, &b)| (a as f64 + b as f64).abs())
+            .fold(0.0f64, f64::max);
+        worst = worst.max(err_pos.min(err_neg));
+    }
+    worst
+}
+
+fn solver_name(level: u8) -> &'static str {
+    match level {
+        0 => "Dense EVD",
+        1 => "LOBPCG",
+        2 => "LOBPCG+reg",
+        3 => "rSVD",
+        4 => "Forced Dense EVD",
+        _ => "Unknown",
+    }
+}
+
+fn process_dataset(dataset: &str, n: usize, is_connected: bool, expected_n_components: usize) -> DatasetMetrics {
+    let base = common::fixture_path(dataset, "");
+
+    let graph = common::load_sparse_csr_f32_u32(&base.join("step5a_pruned.npz"));
+    let laplacian = common::load_sparse_csr(&base.join("comp_b_laplacian.npz"));
+
+    let ref_eigenvalues: Array1<f64> =
+        common::load_dense(&base.join("comp_d_eigensolver.npz"), "eigenvalues");
+    let ref_eigenvectors: Array2<f64> =
+        common::load_dense(&base.join("comp_d_eigensolver.npz"), "eigenvectors");
+
+    let ref_pre_noise: Array2<f32> =
+        common::load_dense(&base.join("comp_f_scaling.npz"), "pre_noise");
+    let expansion_arr: ndarray::Array0<f64> =
+        common::load_dense(&base.join("comp_f_scaling.npz"), "expansion");
+    let expansion_val = expansion_arr.into_scalar();
+
+    let k = ref_eigenvalues.len();
+    let n_components_dim = k - 1;
+
+    // NOTE: solve_eigenproblem_pub uses sqrt_deg = ones(n) internally.
+    let ((eigenvalues, eigenvectors), solver_level) =
+        solve_eigenproblem_pub(&laplacian, n_components_dim, 42);
+
+    let eigenvalue_abs_errors: Vec<f64> = eigenvalues.iter()
+        .zip(ref_eigenvalues.iter())
+        .map(|(r, re)| (r - re).abs())
+        .collect();
+    let eigenvalue_rel_errors: Vec<f64> = eigenvalues.iter()
+        .zip(ref_eigenvalues.iter())
+        .map(|(r, re)| (r - re).abs() / re.abs().max(1e-300))
+        .collect();
+
+    let per_eigenvec_residuals: Vec<f64> = (0..eigenvectors.ncols())
+        .map(|j| common::residual_spmv(&laplacian, eigenvectors.column(j), eigenvalues[j]))
+        .collect();
+    let max_residual = per_eigenvec_residuals.iter().cloned().fold(0.0f64, f64::max);
+
+    let subspace_gram_det = if k >= 3 && ref_eigenvectors.ncols() >= 3 {
+        Some(gram_det_2d(
+            eigenvectors.column(1), eigenvectors.column(2),
+            ref_eigenvectors.column(1), ref_eigenvectors.column(2),
+        ))
+    } else {
+        None
+    };
+
+    let selected = select_eigenvectors(
+        eigenvalues.as_slice_memory_order().expect("eigenvalues contiguous"),
+        &eigenvectors,
+        n_components_dim,
+    );
+    let rust_pre_noise = compute_rust_pre_noise(&selected);
+    let pn_max_err = pre_noise_max_err(&rust_pre_noise, &ref_pre_noise);
+
+    let e2e_max_residual = if is_connected {
+        let result = spectral_init(&graph, n_components_dim, 42, None)
+            .unwrap_or_else(|e| panic!("{dataset}: spectral_init failed: {e}"));
+        let e2e_max = (0..n_components_dim).map(|col| {
+            let evec: Array1<f64> = result.column(col).mapv(|v| v as f64 / expansion_val);
+            common::residual_spmv(&laplacian, evec.view(), ref_eigenvalues[col + 1])
+        }).fold(0.0f64, f64::max);
+        Some(e2e_max)
+    } else {
+        None
+    };
+
+    let (_, rust_n_components) = find_components(&graph);
+    let component_count_matches = rust_n_components == expected_n_components;
+
+    DatasetMetrics {
+        dataset: dataset.to_string(),
+        n,
+        n_components: expected_n_components,
+        is_connected,
+        solver_level: Some(solver_level),
+        solver_name: solver_name(solver_level),
+        eigenvalues_rust: eigenvalues.to_vec(),
+        eigenvalues_ref: ref_eigenvalues.to_vec(),
+        eigenvalue_abs_errors,
+        eigenvalue_rel_errors,
+        per_eigenvec_residuals,
+        max_residual,
+        subspace_gram_det,
+        pre_noise_max_err: pn_max_err,
+        e2e_max_residual,
+        component_count_matches,
+    }
+}
+
+fn build_tolerance_margin_table(all_metrics: &[DatasetMetrics]) -> Vec<ToleranceMarginEntry> {
+    let mut margins = Vec::new();
+
+    // comp_a: max relative degree error
+    let mut worst_deg_rel = 0.0f64;
+    for metric in all_metrics {
+        let base = common::fixture_path(&metric.dataset, "");
+        let graph = common::load_sparse_csr_f32_u32(&base.join("step5a_pruned.npz"));
+        let (degrees, _) = compute_degrees(&graph);
+        let ref_deg: Array1<f64> = common::load_dense(&base.join("comp_a_degrees.npz"), "degrees");
+        for (&got, &want) in degrees.iter().zip(ref_deg.iter()) {
+            let rel_err = (got - want).abs() / want.abs().max(1.0);
+            worst_deg_rel = worst_deg_rel.max(rel_err);
+        }
+    }
+    margins.push(ToleranceMarginEntry {
+        component: "comp_a degrees (relative)".to_string(),
+        tolerance: 3e-7,
+        tolerance_type: "relative",
+        worst_actual: worst_deg_rel,
+        margin_factor: if worst_deg_rel == 0.0 { f64::INFINITY } else { 3e-7 / worst_deg_rel },
+    });
+
+    // comp_b: max absolute Laplacian entry error
+    let mut worst_lap_abs = 0.0f64;
+    for metric in all_metrics {
+        let base = common::fixture_path(&metric.dataset, "");
+        let graph = common::load_sparse_csr_f32_u32(&base.join("step5a_pruned.npz"));
+        let (_, sqrt_deg) = compute_degrees(&graph);
+        let inv_sqrt_deg: Vec<f64> = sqrt_deg.iter()
+            .map(|&s| if s > 0.0 { 1.0 / s } else { 0.0 })
+            .collect();
+        let rust_lap = build_normalized_laplacian(&graph, &inv_sqrt_deg);
+        let ref_lap = common::load_sparse_csr(&base.join("comp_b_laplacian.npz"));
+        for (val, (row, col)) in ref_lap.iter() {
+            let rust_val = rust_lap.get(row, col).copied().unwrap_or(0.0);
+            worst_lap_abs = worst_lap_abs.max((rust_val - val).abs());
+        }
+    }
+    margins.push(ToleranceMarginEntry {
+        component: "comp_b Laplacian entries (absolute)".to_string(),
+        tolerance: 1e-14,
+        tolerance_type: "absolute",
+        worst_actual: worst_lap_abs,
+        margin_factor: if worst_lap_abs == 0.0 { f64::INFINITY } else { 1e-14 / worst_lap_abs },
+    });
+
+    // comp_d: eigenvalue errors — split by n (dense EVD: n<2000, LOBPCG: n>=2000)
+    let worst_eig_dense = all_metrics.iter()
+        .filter(|m| m.n < 2000)
+        .flat_map(|m| m.eigenvalue_abs_errors.iter())
+        .cloned()
+        .fold(0.0f64, f64::max);
+    margins.push(ToleranceMarginEntry {
+        component: "comp_d eigenvalues, Dense EVD (n<2000)".to_string(),
+        tolerance: 1e-8,
+        tolerance_type: "absolute",
+        worst_actual: worst_eig_dense,
+        margin_factor: if worst_eig_dense == 0.0 { f64::INFINITY } else { 1e-8 / worst_eig_dense },
+    });
+
+    let worst_eig_lobpcg = all_metrics.iter()
+        .filter(|m| m.n >= 2000)
+        .flat_map(|m| m.eigenvalue_abs_errors.iter())
+        .cloned()
+        .fold(0.0f64, f64::max);
+    margins.push(ToleranceMarginEntry {
+        component: "comp_d eigenvalues, LOBPCG (n>=2000)".to_string(),
+        tolerance: 1e-6,
+        tolerance_type: "absolute",
+        worst_actual: worst_eig_lobpcg,
+        margin_factor: if worst_eig_lobpcg == 0.0 { f64::INFINITY } else { 1e-6 / worst_eig_lobpcg },
+    });
+
+    // comp_d: residuals — split by n
+    let worst_res_dense = all_metrics.iter()
+        .filter(|m| m.n < 2000)
+        .map(|m| m.max_residual)
+        .fold(0.0f64, f64::max);
+    margins.push(ToleranceMarginEntry {
+        component: "comp_d residuals, Dense EVD (n<2000)".to_string(),
+        tolerance: 1e-10,
+        tolerance_type: "absolute",
+        worst_actual: worst_res_dense,
+        margin_factor: if worst_res_dense == 0.0 { f64::INFINITY } else { 1e-10 / worst_res_dense },
+    });
+
+    let worst_res_lobpcg = all_metrics.iter()
+        .filter(|m| m.n >= 2000)
+        .map(|m| m.max_residual)
+        .fold(0.0f64, f64::max);
+    margins.push(ToleranceMarginEntry {
+        component: "comp_d residuals, LOBPCG/rSVD (n>=2000)".to_string(),
+        tolerance: 1e-4,
+        tolerance_type: "absolute",
+        worst_actual: worst_res_lobpcg,
+        margin_factor: if worst_res_lobpcg == 0.0 { f64::INFINITY } else { 1e-4 / worst_res_lobpcg },
+    });
+
+    // E2E residuals (connected datasets only)
+    let worst_e2e = all_metrics.iter()
+        .filter_map(|m| m.e2e_max_residual)
+        .fold(0.0f64, f64::max);
+    margins.push(ToleranceMarginEntry {
+        component: "E2E residuals (connected, post-noise)".to_string(),
+        tolerance: 5e-3,
+        tolerance_type: "absolute",
+        worst_actual: worst_e2e,
+        margin_factor: if worst_e2e == 0.0 { f64::INFINITY } else { 5e-3 / worst_e2e },
+    });
+
+    // comp_f pre_noise scaling
+    let worst_pn = all_metrics.iter()
+        .map(|m| m.pre_noise_max_err)
+        .fold(0.0f64, f64::max);
+    let f32_eps = f32::EPSILON as f64;
+    margins.push(ToleranceMarginEntry {
+        component: "comp_f pre_noise scaling".to_string(),
+        tolerance: f32_eps,
+        tolerance_type: "absolute",
+        worst_actual: worst_pn,
+        margin_factor: if worst_pn == 0.0 { f64::INFINITY } else { f32_eps / worst_pn },
+    });
+
+    margins
+}
+
+fn to_json(report: &AccuracyReport) -> String {
+    use serde_json::json;
+
+    let datasets: Vec<serde_json::Value> = report.datasets.iter().map(|m| {
+        let lambda_3_abs_err = m.eigenvalue_abs_errors.get(2).copied();
+        let lambda_3_rel_err = m.eigenvalue_rel_errors.get(2).copied();
+        json!({
+            "dataset": m.dataset,
+            "n": m.n,
+            "n_components": m.n_components,
+            "is_connected": m.is_connected,
+            "solver_level": m.solver_level,
+            "solver_name": m.solver_name,
+            "lambda_2_abs_err": m.eigenvalue_abs_errors.get(1).copied(),
+            "lambda_2_rel_err": m.eigenvalue_rel_errors.get(1).copied(),
+            "lambda_3_abs_err": lambda_3_abs_err,
+            "lambda_3_rel_err": lambda_3_rel_err,
+            "per_eigenvec_residuals": m.per_eigenvec_residuals,
+            "max_residual": m.max_residual,
+            "subspace_gram_det": m.subspace_gram_det,
+            "pre_noise_max_err": m.pre_noise_max_err,
+            "e2e_max_residual": m.e2e_max_residual,
+            "component_count_matches": m.component_count_matches,
+        })
+    }).collect();
+
+    let margins: Vec<serde_json::Value> = report.tolerance_margins.iter().map(|m| {
+        let margin_factor = if m.margin_factor.is_infinite() || m.margin_factor.is_nan() {
+            json!(null)
+        } else {
+            json!(m.margin_factor)
+        };
+        json!({
+            "component": m.component,
+            "tolerance": m.tolerance,
+            "tolerance_type": m.tolerance_type,
+            "worst_actual": m.worst_actual,
+            "margin_factor": margin_factor,
+        })
+    }).collect();
+
+    let report_val = json!({
+        "generated_at": report.generated_at,
+        "datasets": datasets,
+        "tolerance_margins": margins,
+    });
+
+    serde_json::to_string_pretty(&report_val).expect("JSON serialization failed")
+}
+
+fn to_markdown(report: &AccuracyReport) -> String {
+    let mut out = String::new();
+
+    out.push_str("# Spectral Init Accuracy Report\n");
+    out.push_str(&format!("Generated: {}\n\n", report.generated_at));
+
+    out.push_str("## Per-Dataset Summary\n\n");
+    out.push_str("| Dataset | n | Components | Solver | λ₂ abs err | λ₃ abs err | max residual | subspace det | pre_noise max_err | E2E residual |\n");
+    out.push_str("|---------|---|------------|--------|------------|------------|--------------|--------------|-------------------|--------------|\n");
+
+    for m in &report.datasets {
+        let lambda2 = m.eigenvalue_abs_errors.get(1)
+            .map(|v| format!("{:.2e}", v))
+            .unwrap_or_else(|| "—".to_string());
+        let lambda3 = m.eigenvalue_abs_errors.get(2)
+            .map(|v| format!("{:.2e}", v))
+            .unwrap_or_else(|| "—".to_string());
+        let subspace = m.subspace_gram_det
+            .map(|v| format!("{:.6}", v))
+            .unwrap_or_else(|| "—".to_string());
+        let pn_err = if m.pre_noise_max_err == 0.0 {
+            "(exact)".to_string()
+        } else {
+            format!("{:.2e}", m.pre_noise_max_err)
+        };
+        let e2e = if m.is_connected {
+            m.e2e_max_residual
+                .map(|v| format!("{:.2e}", v))
+                .unwrap_or_else(|| "—".to_string())
+        } else {
+            "N/A".to_string()
+        };
+
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} | {} | {:.2e} | {} | {} | {} |\n",
+            m.dataset, m.n, m.n_components, m.solver_name,
+            lambda2, lambda3, m.max_residual, subspace, pn_err, e2e,
+        ));
+    }
+
+    out.push_str("\n## Tolerance Margin Analysis\n\n");
+    out.push_str("| Component | Tolerance | Worst Actual | Margin Factor |\n");
+    out.push_str("|-----------|-----------|--------------|---------------|\n");
+
+    for m in &report.tolerance_margins {
+        let margin_str = if m.margin_factor.is_infinite() {
+            "∞x".to_string()
+        } else {
+            format!("{:.2}x", m.margin_factor)
+        };
+        out.push_str(&format!(
+            "| {} | {:.2e} | {:.2e} | {} |\n",
+            m.component, m.tolerance, m.worst_actual, margin_str,
+        ));
+    }
+
+    out
+}
+
+#[test]
+fn generate_accuracy_report() {
+    let mut all_metrics: Vec<DatasetMetrics> = Vec::new();
+    for &(dataset, n, is_connected, expected_n_components) in DATASETS {
+        let metrics = process_dataset(dataset, n, is_connected, expected_n_components);
+        all_metrics.push(metrics);
+    }
+
+    let margins = build_tolerance_margin_table(&all_metrics);
+
+    let report = AccuracyReport {
+        generated_at: humantime::format_rfc3339_seconds(std::time::SystemTime::now()).to_string(),
+        datasets: all_metrics,
+        tolerance_margins: margins,
+    };
+
+    let target_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("target");
+    std::fs::create_dir_all(&target_dir).expect("cannot create target/");
+    let md_path   = target_dir.join("accuracy-report.md");
+    let json_path = target_dir.join("accuracy-report.json");
+    let md_text   = to_markdown(&report);
+    let json_text = to_json(&report);
+    std::fs::write(&md_path,   &md_text).expect("cannot write accuracy-report.md");
+    std::fs::write(&json_path, &json_text).expect("cannot write accuracy-report.json");
+    println!("Accuracy report written to:\n  {}\n  {}", md_path.display(), json_path.display());
+
+    assert!(md_path.exists());
+    assert!(json_path.exists());
+
+    let json: serde_json::Value = serde_json::from_str(&json_text).expect("invalid JSON");
+    assert_eq!(json["datasets"].as_array().unwrap().len(), 9,
+        "Report must cover all 9 datasets");
+    for entry in json["datasets"].as_array().unwrap() {
+        let max_r = entry["max_residual"].as_f64()
+            .expect("max_residual must be a number");
+        assert!(max_r.is_finite(), "max_residual must be finite for {}", entry["dataset"]);
+        assert!(
+            entry["component_count_matches"].as_bool().unwrap_or(false),
+            "component count mismatch for {}", entry["dataset"]
+        );
+    }
+    assert!(!json["tolerance_margins"].as_array().unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary

Add `tests/integration/test_accuracy_report.rs`, a `[[test]]` integration test (gated on `--features testing`) that runs the spectral pipeline for all 9 fixture datasets, collects per-dataset numerical accuracy metrics, and writes `target/accuracy-report.md` (Markdown table) and `target/accuracy-report.json` (structured JSON) in a single invocation:

```
cargo test --test test_accuracy_report --features testing -- --nocapture
```

The report covers: solver level, eigenvalue absolute/relative errors, per-eigenvector residuals, subspace Gram determinant, pre-noise scaling accuracy, E2E residual quality (connected datasets), and component count accuracy (disconnected datasets). A tolerance margin table shows how much headroom exists between observed errors and the thresholds asserted in existing integration tests.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    subgraph IntegrationTests ["LAYER N — INTEGRATION TESTS (testing feature)"]
        direction LR
        ACCURACY["★ test_accuracy_report.rs<br/>━━━━━━━━━━<br/>generate_accuracy_report()<br/>all 9 datasets · Markdown + JSON output"]
        OTHER["Other integration tests<br/>━━━━━━━━━━<br/>test_comp_*, test_pipeline<br/>test_e2e_validation"]
    end

    subgraph TestCommon ["LAYER N-1 — TEST UTILITIES"]
        COMMON["tests/common/mod.rs<br/>━━━━━━━━━━<br/>fixture_path · load_dense<br/>load_sparse_csr · residual_spmv"]
    end

    subgraph LibAPI ["LAYER N-2 — PUBLIC LIBRARY API (src/lib.rs)"]
        direction LR
        PUB["spectral_init() · compute_degrees<br/>build_normalized_laplacian · select_eigenvectors<br/>━━━━━━━━━━<br/>Always-public re-exports"]
        TESTING["find_components · solve_eigenproblem_pub<br/>━━━━━━━━━━<br/>#[cfg(feature = testing)] re-exports"]
    end

    subgraph CoreModules ["LAYER N-3 — CORE MODULES"]
        direction LR
        COMP["src/components.rs<br/>━━━━━━━━━━<br/>BFS labelling<br/>sprs CsMatI"]
        LAP["src/laplacian.rs<br/>━━━━━━━━━━<br/>compute_degrees<br/>build_normalized_laplacian"]
        SEL["src/selection.rs<br/>━━━━━━━━━━<br/>select_eigenvectors"]
        SOLVERS["src/solvers/<br/>━━━━━━━━━━<br/>dense EVD · LOBPCG · rSVD<br/>escalation chain (levels 0–4)"]
        SCALING["src/scaling.rs<br/>━━━━━━━━━━<br/>scale_and_add_noise"]
    end

    subgraph External ["LAYER 0 — EXTERNAL DEPENDENCIES"]
        direction LR
        SPRS["sprs 0.11<br/>━━━━━━━━━━<br/>Sparse CSR/CSC/COO"]
        NDARRAY["ndarray 0.17<br/>━━━━━━━━━━<br/>Dense arrays"]
        FAER["faer 0.24<br/>━━━━━━━━━━<br/>Dense EVD · QR"]
        LINFA["linfa-linalg 0.2<br/>━━━━━━━━━━<br/>LOBPCG"]
        SERDE["serde_json 1<br/>━━━━━━━━━━<br/>JSON output"]
        HT["★ humantime 2<br/>━━━━━━━━━━<br/>RFC 3339 timestamps<br/>dev-dependency"]
        NPYNPY["ndarray-npy 0.10<br/>━━━━━━━━━━<br/>NPZ fixture loading"]
    end

    ACCURACY -->|"uses"| COMMON
    OTHER -->|"uses"| COMMON
    ACCURACY -->|"imports (testing feature)"| TESTING
    ACCURACY -->|"imports (public)"| PUB
    OTHER -->|"imports (public)"| PUB
    PUB -->|"re-exports"| LAP
    PUB -->|"re-exports"| SEL
    TESTING -->|"re-exports"| COMP
    TESTING -->|"re-exports"| SOLVERS
    COMP -->|"CsMatI"| SPRS
    LAP -->|"Array1 · TriMat"| NDARRAY
    LAP -->|"CsMatI"| SPRS
    SEL -->|"Array2"| NDARRAY
    SOLVERS -->|"EVD · QR"| FAER
    SOLVERS -->|"eigensolver"| LINFA
    SCALING -->|"Array2"| NDARRAY
    ACCURACY -->|"dev-dep"| SERDE
    ACCURACY -->|"★ dev-dep (new)"| HT
    COMMON -->|"fixture loading"| NPYNPY
    COMMON -->|"JSON"| SERDE

    class ACCURACY newComponent;
    class OTHER cli;
    class COMMON handler;
    class PUB,TESTING phase;
    class COMP,LAP,SEL,SOLVERS,SCALING stateNode;
    class SPRS,NDARRAY,FAER,LINFA,SERDE,NPYNPY integration;
    class HT output;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph Scenario1 ["★ SCENARIO 1: Full Report Generation (9 Datasets)"]
        direction LR
        S1_CMD["cargo test<br/>━━━━━━━━<br/>--test test_accuracy_report<br/>--features testing"]
        S1_LOOP["★ generate_accuracy_report()<br/>━━━━━━━━<br/>iterate DATASETS[9]<br/>process_dataset per entry"]
        S1_MARGIN["★ build_tolerance_margin_table()<br/>━━━━━━━━<br/>comp_a/b/d/f thresholds<br/>margin_factor per component"]
        S1_MD["★ target/accuracy-report.md<br/>━━━━━━━━<br/>per-dataset table<br/>tolerance margin table"]
        S1_JSON["★ target/accuracy-report.json<br/>━━━━━━━━<br/>9 dataset entries<br/>tolerance_margins array"]
        S1_ASSERT["assert: 9 datasets<br/>━━━━━━━━<br/>finite max_residual<br/>component_count_matches"]
    end

    subgraph Scenario2 ["★ SCENARIO 2: Connected Dataset — Eigensolver + E2E"]
        direction LR
        S2_LOAD["Load fixtures<br/>━━━━━━━━<br/>step5a_pruned.npz (graph)<br/>comp_b_laplacian.npz<br/>comp_d_eigensolver.npz<br/>comp_f_scaling.npz"]
        S2_SOLVE["solve_eigenproblem_pub()<br/>━━━━━━━━<br/>escalation: Dense EVD (n<2000)<br/>or LOBPCG (n≥2000)<br/>returns (eigenvalues, eigenvectors, level)"]
        S2_RESIDUAL["residual_spmv()<br/>━━━━━━━━<br/>||L·v − λ·v|| / ||v||<br/>per eigenvector<br/>max_residual"]
        S2_E2E["spectral_init() E2E<br/>━━━━━━━━<br/>full pipeline (graph → coords)<br/>recover scale via expansion<br/>E2E residual quality"]
        S2_GRAM["gram_det_2d()<br/>━━━━━━━━<br/>subspace Gram determinant<br/>eigvec 1 & 2 vs ref"]
    end

    subgraph Scenario3 ["★ SCENARIO 3: Disconnected Dataset — Components + Embedding"]
        direction LR
        S3_LOAD["Load fixtures<br/>━━━━━━━━<br/>step5a_pruned.npz (graph)<br/>comp_c_components.npz"]
        S3_COMP["find_components()<br/>━━━━━━━━<br/>BFS labelling<br/>rust_n_components"]
        S3_CHECK["component_count_matches<br/>━━━━━━━━<br/>rust_n_components == expected<br/>per-dataset assertion"]
        S3_PERNOISE["compute_rust_pre_noise()<br/>━━━━━━━━<br/>scale eigvecs → max_abs=10<br/>cast to f32 → pre_noise"]
        S3_ERR["pre_noise_max_err()<br/>━━━━━━━━<br/>sign-flip-aware col error<br/>vs comp_f_scaling.npz"]
    end

    subgraph Scenario4 ["★ SCENARIO 4: Tolerance Margin Reporting"]
        direction LR
        S4_DEG["compute_degrees() on graph<br/>━━━━━━━━<br/>max rel err vs ref<br/>threshold: 3e-7"]
        S4_LAP["build_normalized_laplacian()<br/>━━━━━━━━<br/>max abs err vs ref nonzeros<br/>threshold: 1e-14"]
        S4_EIGDENSE["Dense EVD datasets (n<2000)<br/>━━━━━━━━<br/>eigenvalue err < 1e-8<br/>residual < 1e-10"]
        S4_EIGLOBPCG["LOBPCG datasets (n≥2000)<br/>━━━━━━━━<br/>eigenvalue err < 1e-6<br/>residual < 1e-4"]
        S4_MARGIN["margin_factor<br/>━━━━━━━━<br/>tolerance / worst_actual<br/>f64::INFINITY if perfect"]
    end

    S1_CMD -->|"invokes"| S1_LOOP
    S1_LOOP -->|"per dataset"| S1_MARGIN
    S1_LOOP -->|"writes"| S1_MD
    S1_LOOP -->|"writes"| S1_JSON
    S1_JSON -->|"assert"| S1_ASSERT
    S2_LOAD -->|"provides L, ref eigs"| S2_SOLVE
    S2_SOLVE -->|"eigenvectors + λ"| S2_RESIDUAL
    S2_SOLVE -->|"eigenvectors"| S2_GRAM
    S2_LOAD -->|"graph"| S2_E2E
    S3_LOAD -->|"graph"| S3_COMP
    S3_COMP -->|"rust_n_components"| S3_CHECK
    S3_LOAD -->|"eigenvectors"| S3_PERNOISE
    S3_PERNOISE -->|"rust pre_noise"| S3_ERR
    S4_DEG --> S4_LAP
    S4_LAP --> S4_EIGDENSE
    S4_EIGDENSE --> S4_EIGLOBPCG
    S4_EIGLOBPCG --> S4_MARGIN

    class S1_CMD cli;
    class S1_LOOP,S1_MARGIN newComponent;
    class S1_MD,S1_JSON output;
    class S1_ASSERT detector;
    class S2_LOAD,S3_LOAD stateNode;
    class S2_SOLVE,S2_RESIDUAL,S2_E2E,S2_GRAM handler;
    class S3_COMP,S3_CHECK,S3_PERNOISE,S3_ERR handler;
    class S4_DEG,S4_LAP,S4_EIGDENSE,S4_EIGLOBPCG phase;
    class S4_MARGIN newComponent;
```

Closes #69

## Implementation Plan

Plan file: `temp/make-plan/accuracy_report_plan_2026-03-21_141200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
