### PR TITLE
Implementation Plan: Fix comp_b Tolerance Anomaly in Accuracy Report

### DIFF
--- a/tests/integration/test_accuracy_report.rs
+++ b/tests/integration/test_accuracy_report.rs
@@ -219,28 +219,57 @@ fn build_tolerance_margin_table(all_metrics: &[DatasetMetrics]) -> Vec<Tolerance
         margin_factor: if worst_deg_rel == 0.0 { f64::INFINITY } else { 3e-7 / worst_deg_rel },
     });
 
-    // comp_b: max absolute Laplacian entry error
-    let mut worst_lap_abs = 0.0f64;
+    // comp_b isolated: Python sqrt_deg (from comp_a_degrees.npz) → Rust Laplacian
+    // This mirrors test_comp_b_laplacian.rs; tolerance 1e-14 is valid here.
+    let mut worst_lap_iso = 0.0f64;
     for metric in all_metrics {
         let base = common::fixture_path(&metric.dataset, "");
         let graph = common::load_sparse_csr_f32_u32(&base.join("step5a_pruned.npz"));
-        let (_, sqrt_deg) = compute_degrees(&graph);
-        let inv_sqrt_deg: Vec<f64> = sqrt_deg.iter()
+        let sqrt_deg: Array1<f64> =
+            common::load_dense(&base.join("comp_a_degrees.npz"), "sqrt_deg");
+        let inv_sqrt_deg: Vec<f64> = sqrt_deg
+            .iter()
             .map(|&s| if s > 0.0 { 1.0 / s } else { 0.0 })
             .collect();
         let rust_lap = build_normalized_laplacian(&graph, &inv_sqrt_deg);
         let ref_lap = common::load_sparse_csr(&base.join("comp_b_laplacian.npz"));
         for (val, (row, col)) in ref_lap.iter() {
             let rust_val = rust_lap.get(row, col).copied().unwrap_or(0.0);
-            worst_lap_abs = worst_lap_abs.max((rust_val - val).abs());
+            worst_lap_iso = worst_lap_iso.max((rust_val - val).abs());
         }
     }
     margins.push(ToleranceMarginEntry {
-        component: "comp_b Laplacian entries (absolute)".to_string(),
+        component: "comp_b Laplacian (isolated: Python degrees)".to_string(),
         tolerance: 1e-14,
         tolerance_type: "absolute",
-        worst_actual: worst_lap_abs,
-        margin_factor: if worst_lap_abs == 0.0 { f64::INFINITY } else { 1e-14 / worst_lap_abs },
+        worst_actual: worst_lap_iso,
+        margin_factor: if worst_lap_iso == 0.0 { f64::INFINITY } else { 1e-14 / worst_lap_iso },
+    });
+
+    // comp_b chained: Rust compute_degrees() → Rust Laplacian
+    // Inherits f32 graph weight precision; tolerance 1e-7 is appropriate.
+    let mut worst_lap_chain = 0.0f64;
+    for metric in all_metrics {
+        let base = common::fixture_path(&metric.dataset, "");
+        let graph = common::load_sparse_csr_f32_u32(&base.join("step5a_pruned.npz"));
+        let (_, sqrt_deg) = compute_degrees(&graph);
+        let inv_sqrt_deg: Vec<f64> = sqrt_deg
+            .iter()
+            .map(|&s| if s > 0.0 { 1.0 / s } else { 0.0 })
+            .collect();
+        let rust_lap = build_normalized_laplacian(&graph, &inv_sqrt_deg);
+        let ref_lap = common::load_sparse_csr(&base.join("comp_b_laplacian.npz"));
+        for (val, (row, col)) in ref_lap.iter() {
+            let rust_val = rust_lap.get(row, col).copied().unwrap_or(0.0);
+            worst_lap_chain = worst_lap_chain.max((rust_val - val).abs());
+        }
+    }
+    margins.push(ToleranceMarginEntry {
+        component: "comp_b Laplacian (chained: Rust degrees)".to_string(),
+        tolerance: 1e-7,
+        tolerance_type: "absolute",
+        worst_actual: worst_lap_chain,
+        margin_factor: if worst_lap_chain == 0.0 { f64::INFINITY } else { 1e-7 / worst_lap_chain },
     });
 
     // comp_d: eigenvalue errors — split by n (dense EVD: n<2000, LOBPCG: n>=2000)
@@ -462,6 +491,43 @@ fn generate_accuracy_report() {
     assert!(json_path.exists());
 
     let json: serde_json::Value = serde_json::from_str(&json_text).expect("invalid JSON");
+
+    // REQ-SPLIT-001: two separate comp_b rows must exist
+    let margins_arr = json["tolerance_margins"].as_array().unwrap();
+
+    let isolated_row = margins_arr.iter().find(|e| {
+        e["component"].as_str().unwrap_or("").contains("isolated: Python degrees")
+    });
+    assert!(isolated_row.is_some(),
+        "Expected a comp_b isolated (Python degrees) row in tolerance_margins");
+
+    let chained_row = margins_arr.iter().find(|e| {
+        e["component"].as_str().unwrap_or("").contains("chained: Rust degrees")
+    });
+    assert!(chained_row.is_some(),
+        "Expected a comp_b chained (Rust degrees) row in tolerance_margins");
+
+    // REQ-SPLIT-002: isolated row tolerance must be 1e-14
+    let iso_tol = isolated_row.unwrap()["tolerance"].as_f64().unwrap();
+    assert!(
+        (iso_tol - 1e-14).abs() < 1e-20,
+        "Isolated comp_b tolerance must be 1e-14, got {iso_tol}"
+    );
+
+    // REQ-SPLIT-003: chained row tolerance must be 1e-7
+    let chain_tol = chained_row.unwrap()["tolerance"].as_f64().unwrap();
+    assert!(
+        (chain_tol - 1e-7).abs() < 1e-13,
+        "Chained comp_b tolerance must be 1e-7, got {chain_tol}"
+    );
+
+    // REQ-SPLIT-004: the old conflated row must no longer exist
+    let old_row = margins_arr.iter().find(|e| {
+        e["component"].as_str().unwrap_or("") == "comp_b Laplacian entries (absolute)"
+    });
+    assert!(old_row.is_none(),
+        "Old conflated comp_b row must be removed from tolerance_margins");
+
     assert_eq!(json["datasets"].as_array().unwrap().len(), 9,
         "Report must cover all 9 datasets");
     for entry in json["datasets"].as_array().unwrap() {


### PR DESCRIPTION
## Summary

The `build_tolerance_margin_table()` function in `tests/integration/test_accuracy_report.rs` emits a single `comp_b Laplacian entries (absolute)` row that conflates two distinct measurement scenarios:

- The **isolated** test (Python sqrt_deg → Rust Laplacian) has true errors near machine epsilon and belongs at tolerance `1e-14`.
- The **chained** test (Rust `compute_degrees()` → Rust Laplacian) inherits f32 precision error from the graph weights and belongs at tolerance `1e-7`.

The fix splits the single row into two clearly-labeled rows so the report accurately represents what is actually being measured.

## Requirements

### SPLIT (Report Splitting)

- **REQ-SPLIT-001:** The comp_b Laplacian tolerance margin must be split into two separate rows: isolated (Python degrees → Rust Laplacian) and chained (Rust degrees → Rust Laplacian).
- **REQ-SPLIT-002:** The isolated row must use tolerance 1e-14.
- **REQ-SPLIT-003:** The chained row must use tolerance 1e-7.
- **REQ-SPLIT-004:** No other tolerance margin table entries may be affected by this change.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([build_tolerance_margin_table])

    subgraph CompA ["comp_a — degree vector accuracy"]
        CA["comp_a degrees (relative)<br/>━━━━━━━━━━<br/>compute_degrees(graph)<br/>vs comp_a_degrees.npz<br/>tolerance: 3e-7 relative"]
    end

    subgraph CompB ["● comp_b — Laplacian accuracy (split into two paths)"]
        direction LR
        BISO["● comp_b Laplacian (isolated: Python degrees)<br/>━━━━━━━━━━<br/>load comp_a_degrees.npz sqrt_deg<br/>→ build_normalized_laplacian<br/>vs comp_b_laplacian.npz<br/>tolerance: 1e-14"]
        BCHAIN["● comp_b Laplacian (chained: Rust degrees)<br/>━━━━━━━━━━<br/>compute_degrees(graph) sqrt_deg<br/>→ build_normalized_laplacian<br/>vs comp_b_laplacian.npz<br/>tolerance: 1e-7"]
    end

    subgraph CompD ["comp_d — eigenvalue accuracy"]
        direction LR
        DEIG["comp_d eigenvalues Dense EVD n<2000<br/>━━━━━━━━━━<br/>tolerance: 1e-8"]
        LEIG["comp_d eigenvalues LOBPCG n>=2000<br/>━━━━━━━━━━<br/>tolerance: 1e-6"]
    end

    subgraph Residuals ["comp_d — residual accuracy"]
        direction LR
        DRES["comp_d residuals Dense EVD n<2000<br/>━━━━━━━━━━<br/>tolerance: 1e-10"]
        LRES["comp_d residuals LOBPCG/rSVD n>=2000<br/>━━━━━━━━━━<br/>tolerance: 1e-4"]
    end

    subgraph E2E_CompF ["E2E + comp_f"]
        direction LR
        E2E["E2E residuals connected post-noise<br/>━━━━━━━━━━<br/>tolerance: 5e-3"]
        COMPF["comp_f pre_noise scaling<br/>━━━━━━━━━━<br/>tolerance: f32::EPSILON"]
    end

    OUTPUT([Vec ToleranceMarginEntry])

    START --> CA
    CA --> BISO
    CA --> BCHAIN
    BISO --> DEIG
    BISO --> LEIG
    BCHAIN --> DEIG
    BCHAIN --> LEIG
    DEIG --> DRES
    LEIG --> LRES
    DRES --> E2E
    LRES --> E2E
    E2E --> COMPF
    COMPF --> OUTPUT

    class START,OUTPUT terminal;
    class CA handler;
    class BISO,BCHAIN newComponent;
    class DEIG,LEIG phase;
    class DRES,LRES phase;
    class E2E,COMPF stateNode;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Entry and exit points |
| Orange | Handler | comp_a degree measurement |
| Green | Modified | ● comp_b split rows (modified by this PR) |
| Purple | Phase | comp_d eigenvalue and residual rows |
| Teal | State | E2E and comp_f rows |

Closes #95

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-c3-20260321-191048-387358/temp/make-plan/fix_comp_b_tolerance_anomaly_plan_2026-03-21_191310.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
