### PR TITLE
Implementation Plan: Match Python's f32 Column-Sum Degree Computation in Laplacian Construction

### DIFF
--- a/benches/spectral_bench.rs
+++ b/benches/spectral_bench.rs
@@ -8,7 +8,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use spectral_init::{
     build_normalized_laplacian, compute_degrees, dense_evd, find_components, lobpcg_solve,
-    rsvd_solve, spectral_init,
+    rsvd_solve, spectral_init, ComputeMode,
 };
 use spectral_init::operator::{spmv_csr, CsrOperator};
 use std::hint::black_box;
@@ -52,7 +52,7 @@ fn make_ring_graph(n: usize, half: usize) -> sprs::CsMatI<f32, u32, usize> {
 /// to SpMV, dense EVD, LOBPCG, and rSVD benchmarks.
 fn make_laplacian(n: usize, half: usize) -> sprs::CsMatI<f64, usize> {
     let graph = make_ring_graph(n, half);
-    let (_deg, sqrt_deg) = compute_degrees(&graph);
+    let (_deg, sqrt_deg) = compute_degrees(&graph, ComputeMode::PythonCompat);
     let inv_sqrt_deg: Vec<f64> = sqrt_deg
         .iter()
         .map(|&s| if s > 0.0 { 1.0 / s } else { 0.0 })
@@ -124,7 +124,7 @@ fn bench_rsvd(c: &mut Criterion) {
 /// Laplacian construction: degrees + D^{-1/2} W D^{-1/2} build.
 fn bench_laplacian_build(c: &mut Criterion) {
     let graph = make_ring_graph(2000, 2);
-    let (_deg, sqrt_deg) = compute_degrees(&graph);
+    let (_deg, sqrt_deg) = compute_degrees(&graph, ComputeMode::PythonCompat);
     let inv_sqrt_deg: Vec<f64> = sqrt_deg
         .iter()
         .map(|&s| if s > 0.0 { 1.0 / s } else { 0.0 })

--- a/src/laplacian.rs
+++ b/src/laplacian.rs
@@ -1,22 +1,49 @@
+use crate::ComputeMode;
 use ndarray::Array1;
 use sprs::{CsMatI, TriMat};
 
+/// f32 column-sum scatter-add: iterates nonzeros and accumulates deg_f32[col] += val in f32,
+/// then returns the raw f32 accumulator. #[inline(never)] prevents LLVM from reordering
+/// f32 additions across inlining boundaries, ensuring platform-consistent order.
+#[inline(never)]
+fn column_sum_f32(graph: &CsMatI<f32, u32, usize>) -> Vec<f32> {
+    let n = graph.cols();
+    let mut deg_f32 = vec![0.0f32; n];
+    for (val, (_row, col)) in graph.iter() {
+        deg_f32[col as usize] += val;
+    }
+    deg_f32
+}
+
 /// Computes per-node degree and its element-wise square root from a sparse graph.
 ///
-/// Sums each CSR row's f32 weights with f64 accumulation to match Python UMAP's
-/// implicit float64 promotion in `graph.sum()`. Returns `(degrees, sqrt_deg)`.
+/// `mode` selects the accumulation algorithm:
+/// - `ComputeMode::PythonCompat` (default): f32 column-sum scatter-add that matches scipy's
+///   `csc_matvec` behavior — iterates nonzeros and accumulates `deg_f32[col] += val` in f32
+///   before widening to f64. Produces bit-for-bit matching results against the Python reference.
+/// - `ComputeMode::RustNative`: f64 row-sum — iterates CSR rows and accumulates f32 weights
+///   with f64 accumulation. Numerically superior but may differ from Python by ~1 ULP.
 ///
-/// Zero-degree (isolated) nodes produce `degrees[i] = 0.0` and `sqrt_deg[i] = 0.0`.
+/// Returns `(degrees, sqrt_deg)`. Zero-degree (isolated) nodes produce
+/// `degrees[i] = 0.0` and `sqrt_deg[i] = 0.0`.
 pub fn compute_degrees(
     graph: &CsMatI<f32, u32, usize>,
+    mode: ComputeMode,
 ) -> (Array1<f64>, Array1<f64>) {
     let n = graph.rows();
-    let mut degrees = Array1::<f64>::zeros(n);
-
-    for (row_idx, row_vec) in graph.outer_iterator().enumerate() {
-        degrees[row_idx] = row_vec.data().iter().map(|&w| w as f64).sum();
-    }
-
+    let degrees: Array1<f64> = match mode {
+        ComputeMode::PythonCompat => {
+            let deg_f32 = column_sum_f32(graph);
+            Array1::from_vec(deg_f32.iter().map(|&d| d as f64).collect())
+        }
+        ComputeMode::RustNative => {
+            let mut degrees = Array1::<f64>::zeros(n);
+            for (row_idx, row_vec) in graph.outer_iterator().enumerate() {
+                degrees[row_idx] = row_vec.data().iter().map(|&w| w as f64).sum();
+            }
+            degrees
+        }
+    };
     let sqrt_deg = degrees.mapv(f64::sqrt);
     (degrees, sqrt_deg)
 }
@@ -74,12 +101,75 @@ mod tests {
         let data = vec![2.0f32, 2.0f32];
         let graph = CsMatI::new((3, 3), indptr, indices, data);
 
-        let (degrees, sqrt_deg) = compute_degrees(&graph);
+        let (degrees, sqrt_deg) = compute_degrees(&graph, ComputeMode::PythonCompat);
 
         assert!((degrees[0] - 2.0_f64).abs() < 1e-15);
         assert!((degrees[1] - 2.0_f64).abs() < 1e-15);
         assert!((degrees[2] - 0.0_f64).abs() < 1e-15); // isolated node
         assert!((sqrt_deg[2] - 0.0_f64).abs() < 1e-15); // sqrt(0) = 0, not NaN
+    }
+
+    #[test]
+    fn compute_degrees_python_compat_matches_column_sum() {
+        // 4-node graph with asymmetric accumulation weights that reveal f32 vs f64 path.
+        // Edges: (0,1,0.3), (1,0,0.3), (1,2,0.7), (2,1,0.7), (2,3,0.5), (3,2,0.5)
+        // Column sums in f32:
+        //   col 0: val 0.3 (from row 1)      → deg[0] = 0.3f32
+        //   col 1: val 0.3 (from row 0) + 0.7 (from row 2) → deg[1] = (0.3f32 + 0.7f32)
+        //   col 2: val 0.7 (from row 1) + 0.5 (from row 3) → deg[2] = (0.7f32 + 0.5f32)
+        //   col 3: val 0.5 (from row 2)      → deg[3] = 0.5f32
+        let indptr = vec![0usize, 1, 3, 5, 6];
+        let indices = vec![1u32, 0u32, 2u32, 1u32, 3u32, 2u32];
+        let data = vec![0.3f32, 0.3f32, 0.7f32, 0.7f32, 0.5f32, 0.5f32];
+        let graph = CsMatI::new((4, 4), indptr, indices, data);
+
+        // Expected column sums in f32 (manually computed):
+        let expected_col_sums: Vec<f32> = {
+            let mut d = vec![0.0f32; 4];
+            // row 0: (col=1, val=0.3)
+            d[1] += 0.3f32;
+            // row 1: (col=0, val=0.3), (col=2, val=0.7)
+            d[0] += 0.3f32;
+            d[2] += 0.7f32;
+            // row 2: (col=1, val=0.7), (col=3, val=0.5)
+            d[1] += 0.7f32;
+            d[3] += 0.5f32;
+            // row 3: (col=2, val=0.5)
+            d[2] += 0.5f32;
+            d
+        };
+
+        let (deg, _) = compute_degrees(&graph, ComputeMode::PythonCompat);
+
+        for i in 0..4 {
+            let expected = expected_col_sums[i] as f64;
+            assert!(
+                (deg[i] - expected).abs() < 1e-15,
+                "deg[{i}]: got {}, expected {} (f32 col-sum widened to f64)",
+                deg[i],
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn compute_degrees_rust_native_uses_f64_row_sum() {
+        // 4-node path graph; verify RustNative sums CSR rows in f64.
+        // For integer-valued weights f32 and f64 row sums are identical.
+        let indptr = vec![0usize, 1, 3, 5, 6];
+        let indices = vec![1u32, 0u32, 2u32, 1u32, 3u32, 2u32];
+        let data = vec![1.0f32; 6];
+        let graph = CsMatI::new((4, 4), indptr, indices, data);
+
+        let (deg, sqrt_deg) = compute_degrees(&graph, ComputeMode::RustNative);
+
+        // Node 0 and 3 have degree 1, nodes 1 and 2 have degree 2
+        assert!((deg[0] - 1.0_f64).abs() < 1e-15, "deg[0]={}", deg[0]);
+        assert!((deg[1] - 2.0_f64).abs() < 1e-15, "deg[1]={}", deg[1]);
+        assert!((deg[2] - 2.0_f64).abs() < 1e-15, "deg[2]={}", deg[2]);
+        assert!((deg[3] - 1.0_f64).abs() < 1e-15, "deg[3]={}", deg[3]);
+        assert!((sqrt_deg[0] - 1.0_f64).abs() < 1e-15);
+        assert!((sqrt_deg[1] - 2.0_f64.sqrt()).abs() < 1e-15);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ pub fn spectral_init(
     }
 
     // ── Component B: degrees and inverse-square-root degrees ──────────────
-    let (_degrees, sqrt_deg) = laplacian::compute_degrees(graph);
+    let (_degrees, sqrt_deg) = laplacian::compute_degrees(graph, config.compute_mode);
     let inv_sqrt_deg: Vec<f64> = sqrt_deg
         .iter()
         .map(|&s| if s > 0.0 { 1.0 / s } else { 0.0 })

--- a/src/multi_component.rs
+++ b/src/multi_component.rs
@@ -264,7 +264,7 @@ fn embed_single_component(
     data_range: f64,
     meta_pos: &ArrayView1<f64>,
     seed: u64,
-    _compute_mode: ComputeMode,
+    compute_mode: ComputeMode,
 ) -> Result<Array2<f64>, SpectralError> {
     let size = members.len();
 
@@ -281,7 +281,7 @@ fn embed_single_component(
 
     // Large component: run the standard spectral pipeline on the subgraph
     let sub_graph = extract_subgraph(graph, members);
-    let (_degrees, sqrt_deg) = compute_degrees(&sub_graph);
+    let (_degrees, sqrt_deg) = compute_degrees(&sub_graph, compute_mode);
     let inv_sqrt_deg: Vec<f64> = sqrt_deg
         .iter()
         .map(|&s| if s > 0.0 { 1.0 / s } else { 0.0 })

--- a/src/solvers/rsvd.rs
+++ b/src/solvers/rsvd.rs
@@ -236,6 +236,7 @@ pub(crate) fn rsvd_solve_accurate(
 mod tests {
     use super::*;
     use crate::laplacian::build_normalized_laplacian;
+    use crate::ComputeMode;
 
     /// Build a sparse graph (CSR f32/u32) from a list of undirected (row, col, weight) edges.
     fn make_graph(n: usize, edges: &[(usize, usize, f32)]) -> sprs::CsMatI<f32, u32, usize> {
@@ -260,7 +261,7 @@ mod tests {
     #[test]
     fn test_two_i_minus_laplacian_path_3() {
         let graph = make_graph(3, &[(0, 1, 1.0), (1, 2, 1.0)]);
-        let (_, sqrt_deg) = crate::laplacian::compute_degrees(&graph);
+        let (_, sqrt_deg) = crate::laplacian::compute_degrees(&graph, ComputeMode::PythonCompat);
         let inv_sqrt_deg = sqrt_deg.mapv(|x| if x == 0.0 { 0.0 } else { 1.0 / x });
         let l = build_normalized_laplacian(&graph, inv_sqrt_deg.as_slice().unwrap());
         let m = two_i_minus_laplacian(&l);
@@ -310,7 +311,7 @@ mod tests {
             .flat_map(|i| (i + 1..n).map(move |j| (i, j, 1.0f32)))
             .collect();
         let graph = make_graph(n, &edges);
-        let (_, sqrt_deg) = crate::laplacian::compute_degrees(&graph);
+        let (_, sqrt_deg) = crate::laplacian::compute_degrees(&graph, ComputeMode::PythonCompat);
         let inv_sqrt_deg = sqrt_deg.mapv(|x| if x == 0.0 { 0.0 } else { 1.0 / x });
         let l = build_normalized_laplacian(&graph, inv_sqrt_deg.as_slice().unwrap());
 
@@ -355,7 +356,7 @@ mod tests {
         let edges: Vec<(usize, usize, f32)> =
             (0..n).map(|i| (i, (i + 1) % n, 1.0f32)).collect();
         let graph = make_graph(n, &edges);
-        let (_, sqrt_deg) = crate::laplacian::compute_degrees(&graph);
+        let (_, sqrt_deg) = crate::laplacian::compute_degrees(&graph, ComputeMode::PythonCompat);
         let inv_sqrt_deg = sqrt_deg.mapv(|x| if x == 0.0 { 0.0 } else { 1.0 / x });
         let l = build_normalized_laplacian(&graph, inv_sqrt_deg.as_slice().unwrap());
 

--- a/tests/integration/test_accuracy_report.rs
+++ b/tests/integration/test_accuracy_report.rs
@@ -180,7 +180,7 @@ fn process_disconnected_path(dataset: &str, n_embedding_dims: usize) -> Disconne
                 return 0.0;
             }
             let sub_graph = extract_subgraph_local(&graph, members);
-            let (_, sqrt_deg_c) = compute_degrees(&sub_graph);
+            let (_, sqrt_deg_c) = compute_degrees(&sub_graph, ComputeMode::PythonCompat);
             let inv_sqrt_c: Vec<f64> = sqrt_deg_c
                 .iter()
                 .map(|&s| if s > 0.0 { 1.0 / s } else { 0.0 })
@@ -404,7 +404,7 @@ fn build_tolerance_margin_table(all_metrics: &[DatasetMetrics]) -> Vec<Tolerance
     for metric in all_metrics {
         let base = common::fixture_path(&metric.dataset, "");
         let graph = common::load_sparse_csr_f32_u32(&base.join("step5a_pruned.npz"));
-        let (degrees, _) = compute_degrees(&graph);
+        let (degrees, _) = compute_degrees(&graph, ComputeMode::PythonCompat);
         let ref_deg: Array1<f64> = common::load_dense(&base.join("comp_a_degrees.npz"), "degrees");
         for (&got, &want) in degrees.iter().zip(ref_deg.iter()) {
             let rel_err = (got - want).abs() / want.abs().max(1.0);
@@ -452,7 +452,7 @@ fn build_tolerance_margin_table(all_metrics: &[DatasetMetrics]) -> Vec<Tolerance
     for metric in all_metrics {
         let base = common::fixture_path(&metric.dataset, "");
         let graph = common::load_sparse_csr_f32_u32(&base.join("step5a_pruned.npz"));
-        let (_, sqrt_deg) = compute_degrees(&graph);
+        let (_, sqrt_deg) = compute_degrees(&graph, ComputeMode::PythonCompat);
         let inv_sqrt_deg: Vec<f64> = sqrt_deg
             .iter()
             .map(|&s| if s > 0.0 { 1.0 / s } else { 0.0 })

--- a/tests/integration/test_comp_a_degrees.rs
+++ b/tests/integration/test_comp_a_degrees.rs
@@ -1,16 +1,16 @@
 #[path = "../common/mod.rs"]
 mod common;
 
-use spectral_init::compute_degrees;
+use spectral_init::{compute_degrees, ComputeMode};
 
-fn run_comp_a_test(dataset: &str, expected_n: usize) {
+fn run_comp_a_test(dataset: &str, expected_n: usize, mode: ComputeMode, tol: f64) {
     let base = common::fixture_path(dataset, "");
 
     // Load the pruned graph (input to compute_degrees)
     let graph = common::load_sparse_csr_f32_u32(&base.join("step5a_pruned.npz"));
 
     // Call the function under test
-    let (degrees, sqrt_deg) = compute_degrees(&graph);
+    let (degrees, sqrt_deg) = compute_degrees(&graph, mode);
 
     // Load Python reference
     let ref_path = base.join("comp_a_degrees.npz");
@@ -20,47 +20,62 @@ fn run_comp_a_test(dataset: &str, expected_n: usize) {
     assert_eq!(degrees.len(), expected_n, "degrees length");
     assert_eq!(sqrt_deg.len(), expected_n, "sqrt_deg length");
 
-    // Relative tolerance of 3e-7 (≈2.5 × f32_epsilon ≈ 2.5 ULPs): input graph
-    // weights are f32, and Python sums columns (axis=0) while Rust sums rows.
-    // Floating-point summation order differs, yielding noise that scales with the
-    // degree magnitude. Observed max relative error across all 9 datasets is
-    // ≈2.2e-7 (≈1.84 f32_epsilon); 3e-7 provides ~37 % headroom while remaining
-    // tight enough to catch genuine degree-computation bugs (which would differ by
-    // ≥1e-4 relative). The `want.abs().max(1.0)` floor avoids divide-by-zero for
-    // the degenerate degree=0 case.
     for (i, (&got, &want)) in degrees.iter().zip(expected_deg.iter()).enumerate() {
-        let tol = 3e-7_f64 * want.abs().max(1.0);
+        let abs_tol = tol * want.abs().max(1.0);
         assert!(
-            (got - want).abs() < tol,
-            "degrees[{i}]: got {got}, want {want}, diff {}, tol {tol}",
+            (got - want).abs() < abs_tol,
+            "degrees[{i}]: got {got}, want {want}, diff {}, tol {abs_tol}",
             (got - want).abs()
         );
     }
     for (i, (&got, &want)) in sqrt_deg.iter().zip(expected_sqrt.iter()).enumerate() {
-        let tol = 3e-7_f64 * want.abs().max(1.0);
+        let abs_tol = tol * want.abs().max(1.0);
         assert!(
-            (got - want).abs() < tol,
-            "sqrt_deg[{i}]: got {got}, want {want}, diff {}, tol {tol}",
+            (got - want).abs() < abs_tol,
+            "sqrt_deg[{i}]: got {got}, want {want}, diff {}, tol {abs_tol}",
             (got - want).abs()
         );
     }
 }
 
-macro_rules! make_comp_a_test {
+// ── PythonCompat tests (tight tolerance 1e-15, bit-for-bit match) ────────────
+
+macro_rules! make_comp_a_python_compat_test {
     ($name:ident, $dataset:literal, $n:expr) => {
         #[test]
         fn $name() {
-            run_comp_a_test($dataset, $n);
+            run_comp_a_test($dataset, $n, ComputeMode::PythonCompat, 1e-15);
         }
     };
 }
 
-make_comp_a_test!(comp_a_degrees_matches_python_blobs_connected_200,  "blobs_connected_200",  200);
-make_comp_a_test!(comp_a_degrees_matches_python_blobs_connected_2000, "blobs_connected_2000", 2000);
-make_comp_a_test!(comp_a_degrees_matches_python_disconnected_200,     "disconnected_200",     200);
-make_comp_a_test!(comp_a_degrees_matches_python_moons_200,            "moons_200",            200);
-make_comp_a_test!(comp_a_degrees_matches_python_circles_300,          "circles_300",          300);
-make_comp_a_test!(comp_a_degrees_matches_python_near_dupes_100,       "near_dupes_100",       100);
-make_comp_a_test!(comp_a_degrees_matches_python_blobs_50,             "blobs_50",             50);
-make_comp_a_test!(comp_a_degrees_matches_python_blobs_500,            "blobs_500",            500);
-make_comp_a_test!(comp_a_degrees_matches_python_blobs_5000,           "blobs_5000",           5000);
+make_comp_a_python_compat_test!(comp_a_degrees_matches_python_blobs_connected_200,  "blobs_connected_200",  200);
+make_comp_a_python_compat_test!(comp_a_degrees_matches_python_blobs_connected_2000, "blobs_connected_2000", 2000);
+make_comp_a_python_compat_test!(comp_a_degrees_matches_python_disconnected_200,     "disconnected_200",     200);
+make_comp_a_python_compat_test!(comp_a_degrees_matches_python_moons_200,            "moons_200",            200);
+make_comp_a_python_compat_test!(comp_a_degrees_matches_python_circles_300,          "circles_300",          300);
+make_comp_a_python_compat_test!(comp_a_degrees_matches_python_near_dupes_100,       "near_dupes_100",       100);
+make_comp_a_python_compat_test!(comp_a_degrees_matches_python_blobs_50,             "blobs_50",             50);
+make_comp_a_python_compat_test!(comp_a_degrees_matches_python_blobs_500,            "blobs_500",            500);
+make_comp_a_python_compat_test!(comp_a_degrees_matches_python_blobs_5000,           "blobs_5000",           5000);
+
+// ── RustNative tests (loose tolerance 3e-7, regression guard) ────────────────
+
+macro_rules! make_comp_a_rust_native_test {
+    ($name:ident, $dataset:literal, $n:expr) => {
+        #[test]
+        fn $name() {
+            run_comp_a_test($dataset, $n, ComputeMode::RustNative, 3e-7);
+        }
+    };
+}
+
+make_comp_a_rust_native_test!(comp_a_degrees_rust_native_blobs_connected_200,  "blobs_connected_200",  200);
+make_comp_a_rust_native_test!(comp_a_degrees_rust_native_blobs_connected_2000, "blobs_connected_2000", 2000);
+make_comp_a_rust_native_test!(comp_a_degrees_rust_native_disconnected_200,     "disconnected_200",     200);
+make_comp_a_rust_native_test!(comp_a_degrees_rust_native_moons_200,            "moons_200",            200);
+make_comp_a_rust_native_test!(comp_a_degrees_rust_native_circles_300,          "circles_300",          300);
+make_comp_a_rust_native_test!(comp_a_degrees_rust_native_near_dupes_100,       "near_dupes_100",       100);
+make_comp_a_rust_native_test!(comp_a_degrees_rust_native_blobs_50,             "blobs_50",             50);
+make_comp_a_rust_native_test!(comp_a_degrees_rust_native_blobs_500,            "blobs_500",            500);
+make_comp_a_rust_native_test!(comp_a_degrees_rust_native_blobs_5000,           "blobs_5000",           5000);


### PR DESCRIPTION
## Summary

Modify `compute_degrees` in `src/laplacian.rs` to accept a `ComputeMode` parameter and branch between two accumulation algorithms:

- **`PythonCompat` (default):** f32 column-sum scatter-add that matches scipy's `csc_matvec` behavior — iterates nonzeros and accumulates `deg_f32[col] += val` in f32 before widening to f64.
- **`RustNative`:** Keep the current f64 row-sum (numerically superior, currently live).

Update all callers (`lib.rs`, `multi_component.rs`, `solvers/rsvd.rs` tests, `test_accuracy_report.rs`, `spectral_bench.rs`) to pass the mode. Tighten the comp_a integration test tolerance from `3e-7` to `1e-15` in `PythonCompat` mode, since the f32 column-sum produces bit-for-bit matching results against the Python reference.

## Requirements

### DEG (Degree Computation)

- **REQ-DEG-001:** In `PythonCompat` mode, degree computation must use f32 column-sum scatter-add matching scipy's `csc_matvec` behavior.
- **REQ-DEG-002:** In `RustNative` mode, degree computation must use f64 row-sum accumulation (current behavior).
- **REQ-DEG-003:** The f32 column-sum must iterate over nonzeros and accumulate `degree[col] += val` in f32 before widening to f64.
- **REQ-DEG-004:** Compiler reordering of f32 additions must be prevented (e.g., `#[inline(never)]` or explicit sequential loop).

### VAL (Validation)

- **REQ-VAL-001:** In `PythonCompat` mode, comp_a degree values must match Python reference to within f64 representation error (~1e-15).
- **REQ-VAL-002:** In `RustNative` mode, existing test behavior must be preserved (no regression).

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    START([spectral_init / embed_disconnected])

    COMP_CHECK{"component count?"}

    subgraph DegComp ["● compute_degrees — laplacian.rs"]
        direction TB
        MODE{"● ComputeMode<br/>━━━━━━━━━━<br/>PythonCompat<br/>or RustNative?"}
        COLSUM["● f32 column-sum scatter-add<br/>━━━━━━━━━━<br/>column_sum_f32 #[inline(never)]<br/>deg_f32[col] += val (f32)<br/>then widen to f64"]
        ROWSUM["f64 row-sum<br/>━━━━━━━━━━<br/>w as f64 per weight<br/>sum() in f64 per row"]
        DEGREES["(degrees: Array1f64,<br/>sqrt_deg: Array1f64)"]
    end

    subgraph LapBuild ["build_normalized_laplacian — laplacian.rs"]
        INV["inv_sqrt_deg<br/>━━━━━━━━━━<br/>1/sqrt(deg) or 0.0"]
        LAP["Symmetric Normalized Laplacian<br/>━━━━━━━━━━<br/>L = I − D^{-1/2} W D^{-1/2}<br/>f64 CSR sparse"]
    end

    subgraph SolveOut ["Solver & Output"]
        SOLVE["solve_eigenproblem<br/>━━━━━━━━━━<br/>dense EVD → LOBPCG →<br/>rSVD escalation chain"]
        OUT["scale_and_add_noise<br/>━━━━━━━━━━<br/>final embedding coords"]
    end

    START --> COMP_CHECK
    COMP_CHECK -->|"single component"| MODE
    COMP_CHECK -->|"multi-component"| MODE

    MODE -->|"PythonCompat (default)"| COLSUM
    MODE -->|"RustNative"| ROWSUM
    COLSUM --> DEGREES
    ROWSUM --> DEGREES
    DEGREES --> INV --> LAP --> SOLVE --> OUT

    END_NODE([embedding Array2f32])
    OUT --> END_NODE

    %% CLASS ASSIGNMENTS %%
    class START,END_NODE terminal;
    class COMP_CHECK detector;
    class MODE detector;
    class COLSUM newComponent;
    class ROWSUM,INV handler;
    class DEGREES,LAP phase;
    class SOLVE,OUT handler;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    subgraph L5 ["LAYER 5 — TESTS / BENCH"]
        direction LR
        BENCH["● benches/spectral_bench.rs<br/>━━━━━━━━━━<br/>+ ComputeMode import"]
        TCOMP["● tests/integration/test_comp_a_degrees.rs<br/>━━━━━━━━━━<br/>+ ComputeMode, PythonCompat + RustNative tests"]
        TACC["● tests/integration/test_accuracy_report.rs<br/>━━━━━━━━━━<br/>+ ComputeMode import"]
    end

    subgraph L4 ["LAYER 4 — PUBLIC API"]
        LIB["● src/lib.rs<br/>━━━━━━━━━━<br/>pub use ComputeMode<br/>passes config.compute_mode to callers"]
    end

    subgraph L3 ["LAYER 3 — ORCHESTRATION"]
        MULTI["● src/multi_component.rs<br/>━━━━━━━━━━<br/>threads ComputeMode through<br/>embed_disconnected → embed_single_component"]
    end

    subgraph L2 ["LAYER 2 — CORE ALGORITHMS"]
        LAP["● src/laplacian.rs<br/>━━━━━━━━━━<br/>● compute_degrees(graph, mode)<br/>PythonCompat: f32 col-sum<br/>RustNative: f64 row-sum"]
    end

    subgraph L1 ["LAYER 1 — PRIMITIVES"]
        direction LR
        CFG["src/config.rs<br/>━━━━━━━━━━<br/>ComputeMode enum<br/>SpectralInitConfig"]
        SOLVERS["● src/solvers/rsvd.rs<br/>━━━━━━━━━━<br/>+ ComputeMode in #[cfg(test)]"]
        COMPS["src/components.rs"]
        SCALE["src/scaling.rs"]
    end

    subgraph L0 ["LAYER 0 — EXTERNAL CRATES"]
        direction LR
        EXT["sprs · ndarray · faer · rand · criterion"]
    end

    %% DEPENDENCIES %%
    BENCH -->|"use spectral_init::{ComputeMode, compute_degrees}"| LIB
    TCOMP -->|"use spectral_init::{compute_degrees, ComputeMode}"| LIB
    TACC -->|"use spectral_init::{ComputeMode, ...}"| LIB

    LIB -->|"compute_mode"| LAP
    LIB -->|"compute_mode"| MULTI
    LIB -->|"pub use"| CFG

    MULTI -->|"compute_degrees(mode)"| LAP
    MULTI -->|"use crate::ComputeMode"| CFG
    MULTI -->|"solve_eigenproblem"| SOLVERS

    LAP -->|"use crate::ComputeMode"| CFG
    LAP --> EXT

    SOLVERS -->|"use crate::ComputeMode (test only)"| CFG
    SOLVERS --> EXT
    COMPS --> EXT
    SCALE --> EXT
    CFG --> EXT

    %% CLASS ASSIGNMENTS %%
    class BENCH,TCOMP,TACC cli;
    class LIB phase;
    class MULTI handler;
    class LAP newComponent;
    class CFG stateNode;
    class SOLVERS,COMPS,SCALE handler;
    class EXT integration;
```

Closes #88

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-a1-20260321-191044-282045/temp/make-plan/match_python_f32_column_sum_degree_plan_2026-03-21_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
