### PR TITLE
Tighten LOBPCG Convergence Tolerance After Preconditioning

### DIFF
--- a/src/solvers/lobpcg.rs
+++ b/src/solvers/lobpcg.rs
@@ -53,7 +53,9 @@ fn from_nd16_array2(a: nd16::Array2<f64>) -> Array2<f64> {
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Residual threshold used to accept partially-converged LOBPCG results.
-const LOBPCG_ACCEPT_TOL: f64 = 1e-4;
+/// Set to 1e-5 (Issue #92 REQ-TOL-003): matches the solver's `tol` and is achievable
+/// with ChFSI-filtered starting subspace for well-conditioned graphs.
+const LOBPCG_ACCEPT_TOL: f64 = 1e-5;
 
 /// Epsilon shift applied to the operator in Level 2 (regularized) LOBPCG.
 pub const REGULARIZATION_EPS: f64 = 1e-5;
@@ -325,7 +327,7 @@ mod tests {
         // All residuals must be below tolerance — verifies eigenvector quality.
         for i in 0..eigvals.len() {
             let r = residual(&op, eigvecs.column(i), eigvals[i]);
-            assert!(r < 1e-4, "residual for eigenpair {i}: {r} >= 1e-4");
+            assert!(r < 1e-5, "residual for eigenpair {i}: {r} >= 1e-5");
         }
     }
 
@@ -352,7 +354,7 @@ mod tests {
 
         for i in 0..eigvals.len() {
             let r = residual(&op, eigvecs.column(i), eigvals[i]);
-            assert!(r < 1e-4, "residual for eigenpair {i}: {r} >= 1e-4");
+            assert!(r < 1e-5, "residual for eigenpair {i}: {r} >= 1e-5");
         }
     }
 
@@ -386,7 +388,7 @@ mod tests {
         // Residual check against original Laplacian — no manual shift needed by the caller
         for i in 0..eigvals.len() {
             let r = residual(&op, eigvecs.column(i), eigvals[i]);
-            assert!(r < 1e-4, "level2 residual for eigenpair {i}: {r} >= 1e-4");
+            assert!(r < 1e-5, "level2 residual for eigenpair {i}: {r} >= 1e-5");
         }
     }
 
@@ -468,6 +470,13 @@ mod tests {
                 result[[i, 0]]
             );
         }
+    }
+
+    #[test]
+    fn lobpcg_accept_tol_is_1e5() {
+        // REQ-TOL-003: partial-convergence acceptance tolerance must be 1e-5.
+        assert_eq!(LOBPCG_ACCEPT_TOL, 1e-5_f64,
+            "LOBPCG_ACCEPT_TOL must be 1e-5 per Issue #92 REQ-TOL-003");
     }
 
     #[test]

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -35,9 +35,9 @@ const RSVD_QUALITY_THRESHOLD: f64 = 1e-2;
 const DENSE_EVD_QUALITY_THRESHOLD: f64 = 1e-6;
 
 /// Maximum acceptable max-residual from LOBPCG before escalating.
-/// LOBPCG is iterative; 1e-3 matches its practical convergence tolerance
-/// while being tighter than rSVD (1e-2).
-const LOBPCG_QUALITY_THRESHOLD: f64 = 1e-3;
+/// Set to 1e-5 (Issue #92 REQ-TOL-002): matches the solver's `tol = 1e-5` and is
+/// consistently achievable with ChFSI preconditioning, while being tighter than rSVD (1e-2).
+const LOBPCG_QUALITY_THRESHOLD: f64 = 1e-5;
 
 /// Maximum acceptable max-residual from shift-and-invert LOBPCG.
 /// Sinv achieves near-exact results (like dense EVD); 1e-6 accepts all
@@ -234,6 +234,13 @@ mod tests {
     }
 
     #[test]
+    fn lobpcg_quality_threshold_is_1e5() {
+        // REQ-TOL-002: LOBPCG quality gate in escalation chain must be 1e-5.
+        assert_eq!(LOBPCG_QUALITY_THRESHOLD, 1e-5_f64,
+            "LOBPCG_QUALITY_THRESHOLD must be 1e-5 per Issue #92 REQ-TOL-002");
+    }
+
+    #[test]
     fn solve_eigenproblem_eigenvalues_nonneg_and_sorted() {
         let laplacian = path_graph_laplacian_6();
         let ((eigvals, _), _) = solve_eigenproblem(&laplacian, 2, 42, &ndarray::Array1::ones(6));
@@ -400,15 +407,15 @@ mod tests {
         // 3-node path graph Laplacian (same structure as above).
         // Construct a near-eigenvector v = v0 + δ·v1 where v0=[1,1,1]/√3 (λ=0) and
         // v1=[1,0,-1]/√2 (λ=1). The residual against eigenvalue 0 is ≈ δ.
-        // With δ=1e-4 the residual sits between DENSE_EVD_QUALITY_THRESHOLD (1e-6) and
-        // LOBPCG_QUALITY_THRESHOLD (1e-3), giving independent coverage of the LOBPCG gate.
+        // With δ=5e-6 the residual sits between DENSE_EVD_QUALITY_THRESHOLD (1e-6) and
+        // LOBPCG_QUALITY_THRESHOLD (1e-5), giving independent coverage of the LOBPCG gate.
         let laplacian = CsMatI::new(
             (3, 3),
             vec![0usize, 2, 5, 7],
             vec![0usize, 1, 0, 1, 2, 1, 2],
             vec![1.0_f64, -1.0, -1.0, 2.0, -1.0, -1.0, 1.0],
         );
-        let delta = 1e-4_f64;
+        let delta = 5e-6_f64;
         let inv_sqrt3 = 1.0_f64 / 3.0_f64.sqrt();
         let inv_sqrt2 = 1.0_f64 / 2.0_f64.sqrt();
         // v = v0 + δ·v1: perturbs the exact λ=0 eigenvector toward the λ=1 eigenvector.

--- a/tests/integration/test_comp_f_lobpcg.rs
+++ b/tests/integration/test_comp_f_lobpcg.rs
@@ -2,7 +2,7 @@
 mod common;
 
 use spectral_init::operator::CsrOperator;
-use spectral_init::solvers::lobpcg::{lobpcg_solve, REGULARIZATION_EPS};
+use spectral_init::solvers::lobpcg::lobpcg_solve;
 
 fn run_lobpcg_test(dataset: &str, _expected_n: usize, regularized: bool) {
     let fixture_dir = common::fixture_path(dataset, "");
@@ -43,22 +43,21 @@ fn run_lobpcg_test(dataset: &str, _expected_n: usize, regularized: bool) {
         for i in 0..eigvals.len() {
             let residual = common::eigenpair_residual(&op, eigvecs.column(i), eigvals[i]);
             assert!(
-                residual < 1e-4,
-                "dataset={dataset}, residual for eigenpair {i}: {residual} >= 1e-4"
+                residual < 1e-5,
+                "dataset={dataset}, residual for eigenpair {i}: {residual} >= 1e-5"
             );
         }
     } else {
-        // Level 2: residuals against the unshifted Laplacian must be < 1e-4.
-        // REGULARIZATION_EPS shift is subtracted before computing residual.
+        // Level 2: residuals against the unshifted Laplacian must be < 1e-5.
         for i in 0..eigvals.len() {
             let residual = common::eigenpair_residual(
                 &op,
                 eigvecs.column(i),
-                eigvals[i] - REGULARIZATION_EPS,
+                eigvals[i],
             );
             assert!(
-                residual < 1e-4,
-                "dataset={dataset}, level2 residual for eigenpair {i}: {residual} >= 1e-4"
+                residual < 1e-5,
+                "dataset={dataset}, level2 residual for eigenpair {i}: {residual} >= 1e-5"
             );
         }
     }


### PR DESCRIPTION
## Summary

Issue #92 requires three tolerance constants to be tightened now that Chebyshev-Filtered Subspace Iteration (ChFSI) preconditioning is in place. One constant (`tol: f32 = 1e-5`) is already set correctly per the in-code comment; the two remaining changes are:

1. `LOBPCG_ACCEPT_TOL` in `src/solvers/lobpcg.rs`: `1e-4` → `1e-5` (REQ-TOL-003)
2. `LOBPCG_QUALITY_THRESHOLD` in `src/solvers/mod.rs`: `1e-3` → `1e-5` (REQ-TOL-002)

Both changes flow through to test assertions that hardcode the old tolerances and must be updated to reflect the tighter (correct) behavior.

## Requirements

### TOL (Tolerance Tightening)

- **REQ-TOL-001:** The LOBPCG convergence tolerance must be tightened from 1e-4 to 1e-6 (or 1e-5 as intermediate step).
- **REQ-TOL-002:** The LOBPCG quality threshold in the escalation chain must be tightened from 1e-3 to 1e-5.
- **REQ-TOL-003:** The LOBPCG partial convergence acceptance tolerance must be tightened from 1e-4 to 1e-5.

### GUARD (Safety)

- **REQ-GUARD-001:** This change must only land after preconditioning (#90 or #91) is in place to ensure convergence at the tighter tolerance.
- **REQ-GUARD-002:** Dense EVD datasets (n < 2000) must not be affected by this change.
- **REQ-GUARD-003:** Runtime must remain reasonable — convergence must complete within the existing maxiter budget.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START(["START\nsolve_eigenproblem(L, k, seed)"])
    DONE(["RETURN eigenpairs + level"])

    %% LEVEL 0 %%
    subgraph L0 ["Level 0 — Dense EVD"]
        direction TB
        SizeGate{"n < 2000?"}
        DenseEVD["dense_evd(L, k+1)"]
        DenseGate{"residual\n< 1e-6?"}
    end

    %% LEVEL 1 %%
    subgraph L1 ["Level 1 — LOBPCG (plain)"]
        direction TB
        LOBPCG1["lobpcg_solve(reg=false)\ntol=1e-5, ChFSI if n≥1000\nLOBPCG_ACCEPT_TOL=1e-5"]
        LobpcgGate1{"● residual\n< 1e-5?\n(was 1e-3)"}
    end

    %% LEVEL 2 %%
    subgraph L2 ["Level 2 — Shift-and-Invert LOBPCG"]
        direction TB
        SinvLOBPCG["lobpcg_sinv_solve(L)\nCholesky factorize L+εI"]
        SinvGate{"residual\n< 1e-6?"}
    end

    %% LEVEL 3 %%
    subgraph L3 ["Level 3 — LOBPCG+reg"]
        direction TB
        LOBPCG3["lobpcg_solve(reg=true)\ntol=1e-5, REGULARIZATION_EPS=1e-5\nLOBPCG_ACCEPT_TOL=1e-5"]
        LobpcgGate3{"● residual\n< 1e-5?\n(was 1e-3)"}
    end

    %% LEVEL 4 %%
    subgraph L4 ["Level 4 — Randomized SVD"]
        direction TB
        RSVD["rsvd_solve(L, k, seed)\n2I-L trick, 2 power iters"]
        RsvdGate{"residual\n< 1e-2?"}
    end

    %% LEVEL 5 %%
    subgraph L5 ["Level 5 — Forced Dense EVD"]
        direction TB
        ForcedDense["dense_evd(L, k+1)\npanic on failure"]
    end

    %% FLOW %%
    START --> SizeGate
    SizeGate -->|"yes (n < 2000)"| DenseEVD
    SizeGate -->|"no (n ≥ 2000)"| LOBPCG1
    DenseEVD --> DenseGate
    DenseGate -->|"pass"| DONE
    DenseGate -->|"fail / error"| LOBPCG1
    LOBPCG1 --> LobpcgGate1
    LobpcgGate1 -->|"pass"| DONE
    LobpcgGate1 -->|"fail / None"| SinvLOBPCG
    SinvLOBPCG --> SinvGate
    SinvGate -->|"pass"| DONE
    SinvGate -->|"fail / None"| LOBPCG3
    LOBPCG3 --> LobpcgGate3
    LobpcgGate3 -->|"pass"| DONE
    LobpcgGate3 -->|"fail / None"| RSVD
    RSVD --> RsvdGate
    RsvdGate -->|"pass"| DONE
    RsvdGate -->|"fail"| ForcedDense
    ForcedDense --> DONE

    %% CLASS ASSIGNMENTS %%
    class START,DONE terminal;
    class SizeGate,DenseGate,SinvGate,RsvdGate stateNode;
    class LobpcgGate1,LobpcgGate3 newComponent;
    class DenseEVD,SinvLOBPCG,RSVD,ForcedDense handler;
    class LOBPCG1,LOBPCG3 newComponent;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Start and return states |
| Teal | State | Decision/quality gates (unchanged) |
| Orange | Handler | Processing nodes (dense EVD, sinv, rSVD) |
| Green (●) | Modified | LOBPCG solver and quality gates changed by Issue #92 |

Closes #92

## Implementation Plan

Plan file: `temp/make-plan/tighten_lobpcg_convergence_tolerance_plan_2026-03-21_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
