### PR TITLE
Correct LOBPCG_ACCEPT_TOL Reference in Issue #120

### DIFF
--- a/docs/umap-spectral-initialization-rust-implementation-report.md
+++ b/docs/umap-spectral-initialization-rust-implementation-report.md
@@ -1647,7 +1647,7 @@ Eight implementation tickets (A1, A2, B1, B2, B4, C1, C2, C3) and one verificati
 | A2 | #100 | Fix fixture generator — remove explicit f64 upcast that real UMAP doesn't do |
 | B1 | #99 | Chebyshev Filtered Subspace Iteration (ChFSI) preconditioning for LOBPCG |
 | B2 | #103 | Shift-and-invert LOBPCG via faer sparse Cholesky (new Level 2 in escalation) |
-| B4 | #104 | Tighten LOBPCG convergence tolerance from 1e-4 to 1e-6 after preconditioning |
+| B4 | #104 | Tighten LOBPCG convergence tolerance from 1e-4 to 1e-5 after preconditioning |
 | C1 | #101 | Accuracy report tests production paths for disconnected graphs (`embed_disconnected`) |
 | C2 | #106 | Per-component residual metrics for disconnected datasets |
 | C3 | #98 | Split comp_b tolerance into isolated and chained measurements |


### PR DESCRIPTION
## Summary

Issue #120 incorrectly states `LOBPCG_ACCEPT_TOL = 1e-4`. The research experiment
(`research/2026-03-22-lobpcg-warm-restart-benefit/report.md`, Recommendation #5)
confirmed the actual code value is `1e-5` (set by PR #104 per REQ-TOL-003).

The only committed file containing an inaccurate tolerance value is the implementation
report: `docs/umap-spectral-initialization-rust-implementation-report.md` line 1650,
which describes ticket B4 as "Tighten LOBPCG convergence tolerance from 1e-4 **to 1e-6**"
— but the actual implemented value for both `LOBPCG_ACCEPT_TOL` and the solver `tol` is
**1e-5** (confirmed in `src/solvers/lobpcg.rs`). The two temp files named in the issue
do not exist on disk (the `temp/` directory is gitignored). No changes are required to
code, tests, or any other file.

Closes #126

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/correct_lobpcg_accept_tol_plan_2026-03-23_174500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
