### PR TITLE
Implementation Plan: Implement Global Structure Metrics (Category D)

### DIFF
--- a/tests/visual_eval/global_metrics.py
+++ b/tests/visual_eval/global_metrics.py
@@ -30,7 +30,7 @@ def random_triplet_accuracy(
 
     Returns
     -------
-    float in [0.5, 1.0] — fraction of triplets with preserved ordering
+    float in [0.0, 1.0] — fraction of triplets with preserved ordering
     """
     rng = np.random.RandomState(seed)
     n = len(X_high)

--- a/tests/visual_eval/test_global_metrics.py
+++ b/tests/visual_eval/test_global_metrics.py
@@ -41,7 +41,7 @@ def test_random_triplet_accuracy_returns_float_in_range():
     from global_metrics import random_triplet_accuracy
     result = random_triplet_accuracy(X_high, X_low_pca)
     assert isinstance(result, float)
-    assert 0.5 <= result <= 1.0
+    assert 0.0 <= result <= 1.0
 
 
 def test_shepard_correlation_returns_dict_with_correct_keys():
@@ -60,7 +60,7 @@ def test_centroid_distance_correlation_returns_float_in_range():
     from global_metrics import centroid_distance_correlation
     result = centroid_distance_correlation(X_high, X_low_pca, labels)
     assert isinstance(result, float)
-    assert -1.0 <= result <= 1.0
+    assert result > 0.9, f"centroid_dist_corr too low for well-separated PCA blobs: {result:.4f}"
 
 
 def test_knn_preservation_returns_float_in_unit_interval():
@@ -68,7 +68,8 @@ def test_knn_preservation_returns_float_in_unit_interval():
     from global_metrics import knn_preservation
     result = knn_preservation(X_high, X_low_pca, k=10)
     assert isinstance(result, float)
-    assert 0.0 <= result <= 1.0
+    assert result >= 0.7, f"knn_preservation too low for PCA-projected blobs: {result:.4f}"
+    assert result <= 1.0
 
 
 def test_compute_global_metrics_returns_required_keys():
@@ -91,6 +92,8 @@ def test_pca_beats_random_directionality():
     bad  = compute_global_metrics(X_high, X_low_random, labels)
     for key in ("triplet_accuracy", "shepard_pearson", "shepard_spearman",
                 "centroid_dist_corr", "knn_preservation"):
+        assert not np.isnan(good[key]), f"{key}: PCA result is NaN"
+        assert not np.isnan(bad[key]), f"{key}: random result is NaN"
         assert good[key] > bad[key], (
             f"{key}: PCA={good[key]:.4f} not > random={bad[key]:.4f}"
         )


### PR DESCRIPTION
## Summary

Create `tests/visual_eval/global_metrics.py` with four metric functions measuring
large-scale distance preservation in UMAP embeddings, plus a `compute_global_metrics()`
convenience function. Create `tests/visual_eval/test_global_metrics.py` with smoke
tests following the three-layer pattern already used by `test_cluster_metrics.py` and
`test_spatial_metrics.py`. All code is pure numpy/scipy/sklearn — no scanpy or anndata.

## Requirements

### API — Function Signatures

- **REQ-API-001:** Each metric function must accept numpy arrays as input — no AnnData or scanpy objects.
- **REQ-API-002:** Each metric function must return a float (or dict of floats for Shepard).
- **REQ-API-003:** A `compute_global_metrics()` convenience function must exist that runs all 4 metrics and returns a dict.
- **REQ-API-004:** The module must have zero dependency on scanpy, anndata, or polars.

### TRIP — Random Triplet Accuracy

- **REQ-TRIP-001:** Triplet accuracy must subsample points to at most 5000 before computing distance matrices.
- **REQ-TRIP-002:** Triplet accuracy must use `seed=42` for reproducible triplet selection.
- **REQ-TRIP-003:** Triplets where any two indices are equal must be excluded.

### SHEP — Shepard Diagram Correlation

- **REQ-SHEP-001:** Shepard correlation must compute both Pearson and Spearman correlations of pairwise distances.
- **REQ-SHEP-002:** Shepard correlation must subsample to at most `sample_n` points (default 2000).

### CENT — Centroid Distance Correlation

- **REQ-CENT-001:** Centroid distance correlation must compute per-label centroids in both spaces and correlate inter-centroid `pdist` vectors via Spearman.

### KNN — kNN Preservation Rate

- **REQ-KNN-001:** kNN preservation must compute the mean fraction of k-nearest neighbors in high-dim that are also k-nearest in the embedding.
- **REQ-KNN-002:** kNN preservation must default to `k=15` matching the UMAP `n_neighbors` parameter.

### TEST — Smoke Tests

- **REQ-TEST-001:** A smoke test must verify that a PCA 2D projection scores higher on all metrics than a random coordinate permutation.
- **REQ-TEST-002:** Triplet accuracy on an identity-like mapping must approach 1.0.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph TestLayer ["TEST LAYER — tests/visual_eval/"]
        TC["test_cluster_metrics.py<br/>━━━━━━━━━━<br/>Category C tests"]
        TS["test_spatial_metrics.py<br/>━━━━━━━━━━<br/>Category B tests"]
        TG["★ test_global_metrics.py<br/>━━━━━━━━━━<br/>Category D smoke tests"]
    end

    subgraph MetricLayer ["METRIC LAYER — tests/visual_eval/"]
        CM["cluster_metrics.py<br/>━━━━━━━━━━<br/>ARI · NMI · Purity"]
        SM["spatial_metrics.py<br/>━━━━━━━━━━<br/>SNA · Moran's I · PAS"]
        GM["★ global_metrics.py<br/>━━━━━━━━━━<br/>Triplet · Shepard<br/>Centroid · kNN"]
    end

    subgraph ExtLayer ["LAYER 0 — EXTERNAL DEPENDENCIES"]
        NP["numpy<br/>━━━━━━━━━━<br/>Arrays · RNG"]
        SCIPY["scipy<br/>━━━━━━━━━━<br/>pdist · cdist<br/>pearsonr · spearmanr"]
        SKL["sklearn<br/>━━━━━━━━━━<br/>NearestNeighbors<br/>make_blobs · PCA"]
    end

    TC -->|"imports"| CM
    TS -->|"imports"| SM
    TG -->|"imports"| GM

    CM -->|"imports"| NP
    CM -->|"imports"| SKL
    SM -->|"imports"| NP
    SM -->|"imports"| SCIPY
    SM -->|"imports"| SKL
    GM -->|"imports"| NP
    GM -->|"imports"| SCIPY
    GM -->|"imports"| SKL

    class TC,TS phase;
    class TG newComponent;
    class CM,SM handler;
    class GM newComponent;
    class NP,SCIPY,SKL integration;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Purple | Phase | Existing test modules |
| Green (★) | New | New modules added in this PR |
| Orange | Handler | Existing metric modules |
| Red | External | External library dependencies |

Closes #199

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/global_metrics_plan_2026-04-02_140000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | input | output | cached | count | time |
|------|-------|--------|--------|-------|------|
| plan | 26 | 18.5k | 548.5k | 1 | 6m 12s |
| verify | 19 | 11.5k | 518.7k | 1 | 3m 33s |
| implement | 29 | 6.8k | 614.9k | 1 | 3m 20s |
| audit_impl | 15 | 6.2k | 238.9k | 1 | 1m 49s |
| open_pr | 20 | 7.6k | 458.5k | 1 | 3m 46s |
| **Total** | 109 | 50.6k | 2.4M | | 18m 43s |