### PR TITLE
Ship `trustworthiness_subsampled()` in `src/metrics.rs`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,14 +204,14 @@ pub use crate::metrics::{
     SUBSPACE_GRAM_DET_THRESHOLD, check_eigenvalue_bounds, eigenpair_residual,
     eigenvalue_abs_errors, eigenvalue_condition_number, max_eigenpair_residual,
     orthogonality_error, separation_ratio, sign_agnostic_max_error, spectral_gap,
-    subspace_gram_det_kd, tolerance_margin, trustworthiness,
+    subspace_gram_det_kd, tolerance_margin, trustworthiness, trustworthiness_subsampled,
 };
 
 // Re-export trustworthiness for the CLI binary when built with the `cli` feature.
 // The `testing` block above already covers test builds; this separate cfg avoids
 // double-export when both features are active.
 #[cfg(all(feature = "cli", not(feature = "testing")))]
-pub use crate::metrics::trustworthiness;
+pub use crate::metrics::{trustworthiness, trustworthiness_subsampled};
 
 use ndarray::{Array2, ArrayView2};
 use sprs::CsMatI;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -515,7 +515,20 @@ unsafe fn dist_sq_2d_avx2_batch(yi: &[f64], y_flat: &[f64], n: usize, out: &mut 
 /// `G_k = n·k·(2n−3k−1)`: when `k ≥ n/2` this denominator produces T > 1.
 /// The guard uses integer floor division (`n / 2`), matching sklearn's exact boundary
 /// condition (`n_neighbors >= n // 2` raises `ValueError` in sklearn).
-pub fn trustworthiness(x: ArrayView2<f64>, y: ArrayView2<f64>, k: usize) -> f64 {
+/// Shared inner kernel for [`trustworthiness`] and [`trustworthiness_subsampled`].
+///
+/// `query_indices` selects which rows participate as outer "query" points; values
+/// must lie in `[0, n)` and should be unique (duplicates would double-count their
+/// penalty contribution). The per-row computation always runs against the full
+/// `n`-point population. Only the leading factor of the normalization denominator
+/// uses `m = query_indices.len()` — the `(2n − 3k − 1)` factor still uses the
+/// full population `n`.
+fn trustworthiness_inner(
+    x: ArrayView2<f64>,
+    y: ArrayView2<f64>,
+    k: usize,
+    query_indices: &[usize],
+) -> f64 {
     use std::cell::RefCell;
     let n = x.nrows();
     assert_eq!(
@@ -584,8 +597,9 @@ pub fn trustworthiness(x: ArrayView2<f64>, y: ArrayView2<f64>, k: usize) -> f64 
     #[cfg(feature = "profiling")]
     static PENALTY_NS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-    let penalty_sum: f64 = (0..n)
-        .into_par_iter()
+    let penalty_sum: f64 = query_indices
+        .par_iter()
+        .copied()
         .map(|i| {
             let xi = x.row(i);
             let yi = y.row(i);
@@ -760,8 +774,64 @@ pub fn trustworthiness(x: ArrayView2<f64>, y: ArrayView2<f64>, k: usize) -> f64 
         eprintln!("[timing:penalty] {}", PENALTY_NS.load(Ordering::Relaxed));
     }
 
-    let denom = n as f64 * k as f64 * (2 * n).saturating_sub(3 * k + 1) as f64;
+    let m = query_indices.len();
+    let denom = m as f64 * k as f64 * (2 * n).saturating_sub(3 * k + 1) as f64;
     1.0 - penalty_sum * 2.0 / denom
+}
+
+pub fn trustworthiness(x: ArrayView2<f64>, y: ArrayView2<f64>, k: usize) -> f64 {
+    let n = x.nrows();
+    let query_indices: Vec<usize> = (0..n).collect();
+    trustworthiness_inner(x, y, k, &query_indices)
+}
+
+/// Sub-sampled trustworthiness: evaluates only `m` randomly chosen query rows
+/// against the full `n`-point population.
+///
+/// Identical to [`trustworthiness`] except that the outer iteration is restricted
+/// to `m` query rows sampled uniformly without replacement using `seed`. The
+/// per-row computation (full pairwise X-distances, full Y k-NN, rank penalty
+/// scan) still runs against all `n` points — only the outer iterator and the
+/// leading denominator factor change.
+///
+/// # Formula
+/// `T(k, m) = 1 − (2 / (m·k·(2n−3k−1))) · Σ_{i ∈ Q} Σ_{j ∈ U_i(k)} (r(i,j) − k)`
+///
+/// where `Q ⊂ [0, n)` is the set of `m` sampled query rows. The
+/// `(2n − 3k − 1)` factor uses the full population `n`, so when `m == n` the
+/// result is identical to `trustworthiness(x, y, k)`.
+///
+/// # Determinism
+/// The sample is reproducible: equal `seed` values produce equal row sets.
+/// When `m == n`, the function bypasses sampling entirely and uses the full
+/// `0..n` range, guaranteeing parity with `trustworthiness`.
+///
+/// # Panics
+/// Panics if `k == 0`, `k >= n / 2`, `m == 0`, `m > n`, or if `x` and `y` have
+/// different row counts.
+pub fn trustworthiness_subsampled(
+    x: ArrayView2<f64>,
+    y: ArrayView2<f64>,
+    k: usize,
+    m: usize,
+    seed: u64,
+) -> f64 {
+    let n = x.nrows();
+    assert!(m > 0, "trustworthiness_subsampled: m must be > 0");
+    assert!(
+        m <= n,
+        "trustworthiness_subsampled: m must be <= n (got m={m}, n={n})"
+    );
+
+    let query_indices: Vec<usize> = if m == n {
+        (0..n).collect()
+    } else {
+        use rand::SeedableRng;
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+        rand::seq::index::sample(&mut rng, n, m).into_vec()
+    };
+
+    trustworthiness_inner(x, y, k, &query_indices)
 }
 
 // ─── Data structures (testing feature only) ──────────────────────────────────
@@ -1408,6 +1478,173 @@ mod tests {
             let knn: Vec<usize> = dists[..k].iter().map(|&(_, j)| j).collect();
             assert!(!knn.contains(&i), "point {i} appeared in its own k-NN");
         }
+    }
+
+    fn trustworthiness_brute_force_subsampled(
+        x: ndarray::ArrayView2<f64>,
+        y: ndarray::ArrayView2<f64>,
+        k: usize,
+        query_indices: &[usize],
+    ) -> f64 {
+        use std::collections::HashSet;
+        let n = x.nrows();
+        let m = query_indices.len();
+        let penalty_sum: f64 = query_indices
+            .iter()
+            .map(|&i| {
+                let xi = x.row(i);
+                let yi = y.row(i);
+                let mut dist_x: Vec<(f64, usize)> = (0..n)
+                    .map(|j| {
+                        let d: f64 = xi
+                            .iter()
+                            .zip(x.row(j).iter())
+                            .map(|(&a, &b)| (a - b) * (a - b))
+                            .sum();
+                        (d, j)
+                    })
+                    .collect();
+                dist_x.sort_unstable_by(|a, b| a.0.total_cmp(&b.0).then(a.1.cmp(&b.1)));
+                let knn_x: HashSet<usize> = dist_x[1..=k].iter().map(|&(_, j)| j).collect();
+                let mut rank_x = vec![0usize; n];
+                for (rank, &(_, j)) in dist_x.iter().enumerate() {
+                    rank_x[j] = rank;
+                }
+                let mut dist_y: Vec<(f64, usize)> = (0..n)
+                    .filter(|&j| j != i)
+                    .map(|j| {
+                        let d: f64 = yi
+                            .iter()
+                            .zip(y.row(j).iter())
+                            .map(|(&a, &b)| (a - b) * (a - b))
+                            .sum();
+                        (d, j)
+                    })
+                    .collect();
+                dist_y.sort_unstable_by(|a, b| a.0.total_cmp(&b.0).then(a.1.cmp(&b.1)));
+                let knn_y: HashSet<usize> = dist_y[..k].iter().map(|&(_, j)| j).collect();
+                let mut row_penalty = 0u64;
+                for j in &knn_y {
+                    if !knn_x.contains(j) {
+                        row_penalty += (rank_x[*j] - k) as u64;
+                    }
+                }
+                row_penalty as f64
+            })
+            .sum();
+        let denom = m as f64 * k as f64 * (2 * n).saturating_sub(3 * k + 1) as f64;
+        1.0 - penalty_sum * 2.0 / denom
+    }
+
+    #[test]
+    fn t_tws_01_m_equals_n_matches_full_trustworthiness() {
+        use rand::{Rng, SeedableRng};
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(2026);
+        let n = 60;
+        let k = 5;
+        let x = ndarray::Array2::from_shape_fn((n, 8), |_| rng.random::<f64>());
+        let y = ndarray::Array2::from_shape_fn((n, 2), |_| rng.random::<f64>());
+        let t_full = trustworthiness(x.view(), y.view(), k);
+        let t_sub = trustworthiness_subsampled(x.view(), y.view(), k, n, 0);
+        assert!(
+            (t_full - t_sub).abs() < 1e-10,
+            "m==n parity: full={t_full}, subsampled={t_sub}"
+        );
+    }
+
+    #[test]
+    fn t_tws_02_m_less_than_n_in_unit_interval() {
+        use rand::{Rng, SeedableRng};
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(33);
+        let n = 200;
+        let k = 5;
+        let m = 50;
+        let x = ndarray::Array2::from_shape_fn((n, 10), |_| rng.random::<f64>());
+        let y = ndarray::Array2::from_shape_fn((n, 2), |_| rng.random::<f64>());
+        let t = trustworthiness_subsampled(x.view(), y.view(), k, m, 7);
+        assert!(t.is_finite(), "T must be finite, got {t}");
+        assert!(t > 0.0 && t <= 1.0, "T out of (0,1]: {t}");
+    }
+
+    #[test]
+    fn t_tws_03_same_seed_is_deterministic() {
+        use rand::{Rng, SeedableRng};
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(11);
+        let n = 100;
+        let k = 4;
+        let m = 30;
+        let x = ndarray::Array2::from_shape_fn((n, 6), |_| rng.random::<f64>());
+        let y = ndarray::Array2::from_shape_fn((n, 2), |_| rng.random::<f64>());
+        let a = trustworthiness_subsampled(x.view(), y.view(), k, m, 12345);
+        let b = trustworthiness_subsampled(x.view(), y.view(), k, m, 12345);
+        assert_eq!(a, b, "same seed must produce identical result");
+    }
+
+    #[test]
+    fn t_tws_04_different_seeds_produce_different_results() {
+        use rand::{Rng, SeedableRng};
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(99);
+        let n = 100;
+        let k = 4;
+        let m = 20;
+        let x = ndarray::Array2::from_shape_fn((n, 6), |_| rng.random::<f64>());
+        let y = ndarray::Array2::from_shape_fn((n, 2), |_| rng.random::<f64>());
+        let a = trustworthiness_subsampled(x.view(), y.view(), k, m, 1);
+        let b = trustworthiness_subsampled(x.view(), y.view(), k, m, 2);
+        assert_ne!(a, b, "different seeds must produce different samples");
+    }
+
+    #[test]
+    #[should_panic(expected = "m must be <= n")]
+    fn t_tws_05_panics_when_m_exceeds_n() {
+        let n = 20usize;
+        let x = ndarray::Array2::zeros((n, 4));
+        let y = ndarray::Array2::zeros((n, 2));
+        let _ = trustworthiness_subsampled(x.view(), y.view(), 3, n + 1, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "m must be > 0")]
+    fn t_tws_06_panics_when_m_zero() {
+        let n = 20usize;
+        let x = ndarray::Array2::zeros((n, 4));
+        let y = ndarray::Array2::zeros((n, 2));
+        let _ = trustworthiness_subsampled(x.view(), y.view(), 3, 0, 0);
+    }
+
+    #[test]
+    fn t_tws_07_perfect_preservation_subsampled() {
+        let n = 40;
+        let x = ndarray::Array2::from_shape_fn((n, 4), |(i, d)| (i * 4 + d) as f64);
+        let y = x.slice(ndarray::s![.., ..2]).to_owned();
+        let t = trustworthiness_subsampled(x.view(), y.view(), 5, 10, 0);
+        assert!(
+            (t - 1.0).abs() < 1e-12,
+            "perfect preservation: T={t}, expected 1.0"
+        );
+    }
+
+    #[test]
+    fn t_tws_08_brute_force_reference_matches() {
+        use rand::{Rng, SeedableRng};
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(7777);
+        let n = 80;
+        let k = 4;
+        let m = 25;
+        let seed: u64 = 314;
+        let x = ndarray::Array2::from_shape_fn((n, 6), |_| rng.random::<f64>());
+        let y = ndarray::Array2::from_shape_fn((n, 2), |_| rng.random::<f64>());
+
+        // Reproduce the exact same query_indices the production function will use.
+        let mut sample_rng = rand::rngs::SmallRng::seed_from_u64(seed);
+        let query_indices = rand::seq::index::sample(&mut sample_rng, n, m).into_vec();
+
+        let t_prod = trustworthiness_subsampled(x.view(), y.view(), k, m, seed);
+        let t_ref = trustworthiness_brute_force_subsampled(x.view(), y.view(), k, &query_indices);
+        assert!(
+            (t_prod - t_ref).abs() < 1e-12,
+            "subsampled brute-force mismatch: prod={t_prod}, ref={t_ref}"
+        );
     }
 
     #[cfg(feature = "testing")]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -599,167 +599,167 @@ pub(crate) fn trustworthiness_inner(
     static PENALTY_NS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
     let process_row = |i: usize| -> f64 {
-            let xi = x.row(i);
-            let yi = y.row(i);
+        let xi = x.row(i);
+        let yi = y.row(i);
 
-            COMB_DIST_X.with(|dist_x_cell| {
-                COMB_INDICES.with(|indices_cell| {
-                    let mut dist_x = dist_x_cell.borrow_mut();
-                    let mut indices = indices_cell.borrow_mut();
+        COMB_DIST_X.with(|dist_x_cell| {
+            COMB_INDICES.with(|indices_cell| {
+                let mut dist_x = dist_x_cell.borrow_mut();
+                let mut indices = indices_cell.borrow_mut();
 
-                    // ── x_dist step ──────────────────────────────────────────────
-                    #[cfg(feature = "profiling")]
-                    let t_x_dist = std::time::Instant::now();
+                // ── x_dist step ──────────────────────────────────────────────
+                #[cfg(feature = "profiling")]
+                let t_x_dist = std::time::Instant::now();
 
-                    dist_x.clear();
-                    dist_x.resize(n, 0.0f64);
-                    for j in 0..n {
-                        let xj = x.row(j);
-                        dist_x[j] = {
-                            #[cfg(all(
-                                target_arch = "x86_64",
-                                target_feature = "avx2",
-                                target_feature = "fma"
-                            ))]
-                            {
-                                if use_avx2 && d_x >= 10 {
-                                    let si = xi.as_slice().expect("x row must be contiguous");
-                                    let sj = xj.as_slice().expect("x row must be contiguous");
-                                    // SAFETY: runtime + d_x check guarantees AVX2+FMA and >= 10 elements.
-                                    unsafe { dist_sq_avx2_looped(si, sj) }
-                                } else {
-                                    xi.iter()
-                                        .zip(xj.iter())
-                                        .map(|(&a, &b)| (a - b) * (a - b))
-                                        .sum()
-                                }
-                            }
-                            #[cfg(not(all(
-                                target_arch = "x86_64",
-                                target_feature = "avx2",
-                                target_feature = "fma"
-                            )))]
-                            {
+                dist_x.clear();
+                dist_x.resize(n, 0.0f64);
+                for j in 0..n {
+                    let xj = x.row(j);
+                    dist_x[j] = {
+                        #[cfg(all(
+                            target_arch = "x86_64",
+                            target_feature = "avx2",
+                            target_feature = "fma"
+                        ))]
+                        {
+                            if use_avx2 && d_x >= 10 {
+                                let si = xi.as_slice().expect("x row must be contiguous");
+                                let sj = xj.as_slice().expect("x row must be contiguous");
+                                // SAFETY: runtime + d_x check guarantees AVX2+FMA and >= 10 elements.
+                                unsafe { dist_sq_avx2_looped(si, sj) }
+                            } else {
                                 xi.iter()
                                     .zip(xj.iter())
                                     .map(|(&a, &b)| (a - b) * (a - b))
                                     .sum()
                             }
-                        };
-                    }
+                        }
+                        #[cfg(not(all(
+                            target_arch = "x86_64",
+                            target_feature = "avx2",
+                            target_feature = "fma"
+                        )))]
+                        {
+                            xi.iter()
+                                .zip(xj.iter())
+                                .map(|(&a, &b)| (a - b) * (a - b))
+                                .sum()
+                        }
+                    };
+                }
 
-                    #[cfg(feature = "profiling")]
-                    X_DIST_NS.fetch_add(
-                        t_x_dist.elapsed().as_nanos() as u64,
-                        std::sync::atomic::Ordering::Relaxed,
-                    );
+                #[cfg(feature = "profiling")]
+                X_DIST_NS.fetch_add(
+                    t_x_dist.elapsed().as_nanos() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
 
-                    // ── x_sort step ──────────────────────────────────────────────
-                    #[cfg(feature = "profiling")]
-                    let t_x_sort = std::time::Instant::now();
+                // ── x_sort step ──────────────────────────────────────────────
+                #[cfg(feature = "profiling")]
+                let t_x_sort = std::time::Instant::now();
 
-                    indices.clear();
-                    indices.extend(0..n);
-                    indices.select_nth_unstable_by(k, |&a, &b| {
-                        dist_x[a].total_cmp(&dist_x[b]).then(a.cmp(&b))
-                    });
+                indices.clear();
+                indices.extend(0..n);
+                indices.select_nth_unstable_by(k, |&a, &b| {
+                    dist_x[a].total_cmp(&dist_x[b]).then(a.cmp(&b))
+                });
 
-                    let knn_x_set: HashSet<usize> =
-                        indices[..=k].iter().filter(|&&m| m != i).copied().collect();
+                let knn_x_set: HashSet<usize> =
+                    indices[..=k].iter().filter(|&&m| m != i).copied().collect();
 
-                    #[cfg(feature = "profiling")]
-                    X_SORT_NS.fetch_add(
-                        t_x_sort.elapsed().as_nanos() as u64,
-                        std::sync::atomic::Ordering::Relaxed,
-                    );
+                #[cfg(feature = "profiling")]
+                X_SORT_NS.fetch_add(
+                    t_x_sort.elapsed().as_nanos() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
 
-                    // ── y_dist step (flat_simd, replaces BinaryHeap) ─────────────
-                    #[cfg(feature = "profiling")]
-                    let t_y_dist = std::time::Instant::now();
+                // ── y_dist step (flat_simd, replaces BinaryHeap) ─────────────
+                #[cfg(feature = "profiling")]
+                let t_y_dist = std::time::Instant::now();
 
-                    COMB_DIST_Y.with(|dy_cell| {
-                        COMB_INDICES_Y.with(|iy_cell| {
-                            let mut dist_y = dy_cell.borrow_mut();
-                            let mut indices_y = iy_cell.borrow_mut();
+                COMB_DIST_Y.with(|dy_cell| {
+                    COMB_INDICES_Y.with(|iy_cell| {
+                        let mut dist_y = dy_cell.borrow_mut();
+                        let mut indices_y = iy_cell.borrow_mut();
 
-                            dist_y.clear();
-                            dist_y.resize(n, 0.0f64);
+                        dist_y.clear();
+                        dist_y.resize(n, 0.0f64);
 
-                            // Fill Y distances: AVX2 2D batch or scalar fallback.
-                            #[cfg(target_arch = "x86_64")]
-                            if use_avx2_y {
-                                let y_flat = y
-                                    .as_slice()
-                                    .expect("y must be standard layout for AVX2 dispatch");
-                                let yi_slice = &y_flat[i * 2..(i + 1) * 2];
-                                // SAFETY: y_flat has n*d_y elements; yi_slice has 2 elements;
-                                // dist_y has n elements; use_avx2_y guarantees d_y==2,
-                                // standard_layout, and runtime AVX2.
-                                unsafe {
-                                    dist_sq_2d_avx2_batch(yi_slice, y_flat, n, &mut dist_y);
-                                }
-                            } else {
-                                for j in 0..n {
-                                    let yj = y.row(j);
-                                    dist_y[j] = yi
-                                        .iter()
-                                        .zip(yj.iter())
-                                        .map(|(&a, &b)| (a - b) * (a - b))
-                                        .sum();
-                                }
+                        // Fill Y distances: AVX2 2D batch or scalar fallback.
+                        #[cfg(target_arch = "x86_64")]
+                        if use_avx2_y {
+                            let y_flat = y
+                                .as_slice()
+                                .expect("y must be standard layout for AVX2 dispatch");
+                            let yi_slice = &y_flat[i * 2..(i + 1) * 2];
+                            // SAFETY: y_flat has n*d_y elements; yi_slice has 2 elements;
+                            // dist_y has n elements; use_avx2_y guarantees d_y==2,
+                            // standard_layout, and runtime AVX2.
+                            unsafe {
+                                dist_sq_2d_avx2_batch(yi_slice, y_flat, n, &mut dist_y);
                             }
-                            #[cfg(not(target_arch = "x86_64"))]
-                            {
-                                for j in 0..n {
-                                    let yj = y.row(j);
-                                    dist_y[j] = yi
-                                        .iter()
-                                        .zip(yj.iter())
-                                        .map(|(&a, &b)| (a - b) * (a - b))
-                                        .sum();
-                                }
+                        } else {
+                            for j in 0..n {
+                                let yj = y.row(j);
+                                dist_y[j] = yi
+                                    .iter()
+                                    .zip(yj.iter())
+                                    .map(|(&a, &b)| (a - b) * (a - b))
+                                    .sum();
                             }
-
-                            dist_y[i] = f64::INFINITY; // self-exclusion
-
-                            indices_y.clear();
-                            indices_y.extend(0..n);
-                            indices_y.select_nth_unstable_by(k, |&a, &b| {
-                                dist_y[a].total_cmp(&dist_y[b]).then(a.cmp(&b))
-                            });
-
-                            #[cfg(feature = "profiling")]
-                            Y_DIST_NS.fetch_add(
-                                t_y_dist.elapsed().as_nanos() as u64,
-                                std::sync::atomic::Ordering::Relaxed,
-                            );
-
-                            // ── penalty step ──────────────────────────────────────
-                            #[cfg(feature = "profiling")]
-                            let t_penalty = std::time::Instant::now();
-
-                            let mut row_penalty = 0u64;
-                            for &j in &indices_y[..k] {
-                                if !knn_x_set.contains(&j) {
-                                    let dj = dist_x[j];
-                                    let rank: usize = (0..n)
-                                        .filter(|&m| dist_x[m] < dj || (dist_x[m] == dj && m < j))
-                                        .count();
-                                    row_penalty += (rank - k) as u64;
-                                }
+                        }
+                        #[cfg(not(target_arch = "x86_64"))]
+                        {
+                            for j in 0..n {
+                                let yj = y.row(j);
+                                dist_y[j] = yi
+                                    .iter()
+                                    .zip(yj.iter())
+                                    .map(|(&a, &b)| (a - b) * (a - b))
+                                    .sum();
                             }
+                        }
 
-                            #[cfg(feature = "profiling")]
-                            PENALTY_NS.fetch_add(
-                                t_penalty.elapsed().as_nanos() as u64,
-                                std::sync::atomic::Ordering::Relaxed,
-                            );
+                        dist_y[i] = f64::INFINITY; // self-exclusion
 
-                            row_penalty as f64
-                        })
+                        indices_y.clear();
+                        indices_y.extend(0..n);
+                        indices_y.select_nth_unstable_by(k, |&a, &b| {
+                            dist_y[a].total_cmp(&dist_y[b]).then(a.cmp(&b))
+                        });
+
+                        #[cfg(feature = "profiling")]
+                        Y_DIST_NS.fetch_add(
+                            t_y_dist.elapsed().as_nanos() as u64,
+                            std::sync::atomic::Ordering::Relaxed,
+                        );
+
+                        // ── penalty step ──────────────────────────────────────
+                        #[cfg(feature = "profiling")]
+                        let t_penalty = std::time::Instant::now();
+
+                        let mut row_penalty = 0u64;
+                        for &j in &indices_y[..k] {
+                            if !knn_x_set.contains(&j) {
+                                let dj = dist_x[j];
+                                let rank: usize = (0..n)
+                                    .filter(|&m| dist_x[m] < dj || (dist_x[m] == dj && m < j))
+                                    .count();
+                                row_penalty += (rank - k) as u64;
+                            }
+                        }
+
+                        #[cfg(feature = "profiling")]
+                        PENALTY_NS.fetch_add(
+                            t_penalty.elapsed().as_nanos() as u64,
+                            std::sync::atomic::Ordering::Relaxed,
+                        );
+
+                        row_penalty as f64
                     })
                 })
             })
+        })
     };
 
     let penalty_sum: f64 = match query_indices {
@@ -1562,12 +1562,9 @@ mod tests {
         // Hard-coded query indices cross-checked against brute force: guards
         // against constant-output regressions and is independent of the
         // production sampling implementation.
-        let query_indices: Vec<usize> = vec![
-            3, 17, 29, 42, 58, 71, 89, 104, 127, 145, 161, 188,
-        ];
+        let query_indices: Vec<usize> = vec![3, 17, 29, 42, 58, 71, 89, 104, 127, 145, 161, 188];
         let t = trustworthiness_inner(x.view(), y.view(), k, Some(&query_indices));
-        let t_ref =
-            trustworthiness_brute_force_subsampled(x.view(), y.view(), k, &query_indices);
+        let t_ref = trustworthiness_brute_force_subsampled(x.view(), y.view(), k, &query_indices);
         assert!(
             (t - t_ref).abs() < 1e-12,
             "subsampled kernel vs brute force mismatch: inner={t}, brute={t_ref}"
@@ -1663,8 +1660,7 @@ mod tests {
         ];
 
         let t_kernel = trustworthiness_inner(x.view(), y.view(), k, Some(&query_indices));
-        let t_ref =
-            trustworthiness_brute_force_subsampled(x.view(), y.view(), k, &query_indices);
+        let t_ref = trustworthiness_brute_force_subsampled(x.view(), y.view(), k, &query_indices);
         assert!(
             (t_kernel - t_ref).abs() < 1e-12,
             "subsampled brute-force mismatch: kernel={t_kernel}, ref={t_ref}"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -523,11 +523,11 @@ unsafe fn dist_sq_2d_avx2_batch(yi: &[f64], y_flat: &[f64], n: usize, out: &mut 
 /// `n`-point population. Only the leading factor of the normalization denominator
 /// uses `m = query_indices.len()` — the `(2n − 3k − 1)` factor still uses the
 /// full population `n`.
-fn trustworthiness_inner(
+pub(crate) fn trustworthiness_inner(
     x: ArrayView2<f64>,
     y: ArrayView2<f64>,
     k: usize,
-    query_indices: &[usize],
+    query_indices: Option<&[usize]>,
 ) -> f64 {
     use std::cell::RefCell;
     let n = x.nrows();
@@ -543,6 +543,7 @@ fn trustworthiness_inner(
         this constraint is required by the normalization denominator and matches sklearn's ValueError",
         n / 2
     );
+    let m_query = query_indices.map_or(n, |q| q.len());
 
     #[cfg(feature = "profiling")]
     {
@@ -597,10 +598,7 @@ fn trustworthiness_inner(
     #[cfg(feature = "profiling")]
     static PENALTY_NS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-    let penalty_sum: f64 = query_indices
-        .par_iter()
-        .copied()
-        .map(|i| {
+    let process_row = |i: usize| -> f64 {
             let xi = x.row(i);
             let yi = y.row(i);
 
@@ -762,8 +760,12 @@ fn trustworthiness_inner(
                     })
                 })
             })
-        })
-        .sum();
+    };
+
+    let penalty_sum: f64 = match query_indices {
+        None => (0..n).into_par_iter().map(&process_row).sum(),
+        Some(qi) => qi.par_iter().copied().map(&process_row).sum(),
+    };
 
     #[cfg(feature = "profiling")]
     {
@@ -774,15 +776,12 @@ fn trustworthiness_inner(
         eprintln!("[timing:penalty] {}", PENALTY_NS.load(Ordering::Relaxed));
     }
 
-    let m = query_indices.len();
-    let denom = m as f64 * k as f64 * (2 * n).saturating_sub(3 * k + 1) as f64;
+    let denom = m_query as f64 * k as f64 * (2 * n).saturating_sub(3 * k + 1) as f64;
     1.0 - penalty_sum * 2.0 / denom
 }
 
 pub fn trustworthiness(x: ArrayView2<f64>, y: ArrayView2<f64>, k: usize) -> f64 {
-    let n = x.nrows();
-    let query_indices: Vec<usize> = (0..n).collect();
-    trustworthiness_inner(x, y, k, &query_indices)
+    trustworthiness_inner(x, y, k, None)
 }
 
 /// Sub-sampled trustworthiness: evaluates only `m` randomly chosen query rows
@@ -823,15 +822,14 @@ pub fn trustworthiness_subsampled(
         "trustworthiness_subsampled: m must be <= n (got m={m}, n={n})"
     );
 
-    let query_indices: Vec<usize> = if m == n {
-        (0..n).collect()
-    } else {
-        use rand::SeedableRng;
-        let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
-        rand::seq::index::sample(&mut rng, n, m).into_vec()
-    };
+    if m == n {
+        return trustworthiness_inner(x, y, k, None);
+    }
 
-    trustworthiness_inner(x, y, k, &query_indices)
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+    let query_indices = rand::seq::index::sample(&mut rng, n, m).into_vec();
+    trustworthiness_inner(x, y, k, Some(&query_indices))
 }
 
 // ─── Data structures (testing feature only) ──────────────────────────────────

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1556,10 +1556,22 @@ mod tests {
         let mut rng = rand::rngs::SmallRng::seed_from_u64(33);
         let n = 200;
         let k = 5;
-        let m = 50;
         let x = ndarray::Array2::from_shape_fn((n, 10), |_| rng.random::<f64>());
         let y = ndarray::Array2::from_shape_fn((n, 2), |_| rng.random::<f64>());
-        let t = trustworthiness_subsampled(x.view(), y.view(), k, m, 7);
+
+        // Hard-coded query indices cross-checked against brute force: guards
+        // against constant-output regressions and is independent of the
+        // production sampling implementation.
+        let query_indices: Vec<usize> = vec![
+            3, 17, 29, 42, 58, 71, 89, 104, 127, 145, 161, 188,
+        ];
+        let t = trustworthiness_inner(x.view(), y.view(), k, Some(&query_indices));
+        let t_ref =
+            trustworthiness_brute_force_subsampled(x.view(), y.view(), k, &query_indices);
+        assert!(
+            (t - t_ref).abs() < 1e-12,
+            "subsampled kernel vs brute force mismatch: inner={t}, brute={t_ref}"
+        );
         assert!(t.is_finite(), "T must be finite, got {t}");
         assert!(t > 0.0 && t <= 1.0, "T out of (0,1]: {t}");
     }
@@ -1587,9 +1599,22 @@ mod tests {
         let m = 20;
         let x = ndarray::Array2::from_shape_fn((n, 6), |_| rng.random::<f64>());
         let y = ndarray::Array2::from_shape_fn((n, 2), |_| rng.random::<f64>());
+
+        // First verify the sampling layer is seed-dependent, independent of
+        // the metric computation.
+        let mut rng_a = rand::rngs::SmallRng::seed_from_u64(1);
+        let indices_a = rand::seq::index::sample(&mut rng_a, n, m).into_vec();
+        let mut rng_b = rand::rngs::SmallRng::seed_from_u64(2);
+        let indices_b = rand::seq::index::sample(&mut rng_b, n, m).into_vec();
+        assert_ne!(
+            indices_a, indices_b,
+            "different seeds must produce different sampled index sets"
+        );
+
+        // Then verify that the metric values computed on different samples differ.
         let a = trustworthiness_subsampled(x.view(), y.view(), k, m, 1);
         let b = trustworthiness_subsampled(x.view(), y.view(), k, m, 2);
-        assert_ne!(a, b, "different seeds must produce different samples");
+        assert_ne!(a, b, "different seeds must produce different metric values");
     }
 
     #[test]
@@ -1628,20 +1653,21 @@ mod tests {
         let mut rng = rand::rngs::SmallRng::seed_from_u64(7777);
         let n = 80;
         let k = 4;
-        let m = 25;
-        let seed: u64 = 314;
         let x = ndarray::Array2::from_shape_fn((n, 6), |_| rng.random::<f64>());
         let y = ndarray::Array2::from_shape_fn((n, 2), |_| rng.random::<f64>());
 
-        // Reproduce the exact same query_indices the production function will use.
-        let mut sample_rng = rand::rngs::SmallRng::seed_from_u64(seed);
-        let query_indices = rand::seq::index::sample(&mut sample_rng, n, m).into_vec();
+        // Hard-coded query indices decouple this correctness test from the
+        // production sampling implementation (RNG choice, call order).
+        let query_indices: Vec<usize> = vec![
+            2, 7, 13, 19, 23, 28, 34, 41, 46, 52, 55, 58, 61, 64, 67, 70, 73, 75, 77, 79,
+        ];
 
-        let t_prod = trustworthiness_subsampled(x.view(), y.view(), k, m, seed);
-        let t_ref = trustworthiness_brute_force_subsampled(x.view(), y.view(), k, &query_indices);
+        let t_kernel = trustworthiness_inner(x.view(), y.view(), k, Some(&query_indices));
+        let t_ref =
+            trustworthiness_brute_force_subsampled(x.view(), y.view(), k, &query_indices);
         assert!(
-            (t_prod - t_ref).abs() < 1e-12,
-            "subsampled brute-force mismatch: prod={t_prod}, ref={t_ref}"
+            (t_kernel - t_ref).abs() < 1e-12,
+            "subsampled brute-force mismatch: kernel={t_kernel}, ref={t_ref}"
         );
     }
 


### PR DESCRIPTION
## Summary

Add a row-sub-sampled variant of `trustworthiness()` that evaluates only `m` randomly chosen query rows against the full `n`-point population, reusing the entire inner-row computation (SIMD dispatch, thread-local buffers, introselect, penalty rank scan) via an extracted private helper. The two public entry points differ only in (a) which row indices they iterate and (b) the `m` factor in the normalization denominator. The `(2n − 3k − 1)` factor still uses the full population `n`, so the formula collapses to the original `trustworthiness()` when `m == n`.

The refactor extracts a single private helper, `trustworthiness_inner(x, y, k, query_indices)`, that owns the parallel map / per-row closure currently inlined in `trustworthiness()`. Both `trustworthiness()` and `trustworthiness_subsampled()` become thin wrappers that build (or sample) the row-index slice and call the helper. No ComputeMode gating: `trustworthiness()` is independent of ComputeMode, and so is the new variant.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 55, 'rankSpacing': 75, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    subgraph Layer3 ["LAYER 3 — CLIENTS (binaries, benches, integration tests)"]
        direction LR
        BIN_TW["src/bin/trustworthiness.rs<br/>━━━━━━━━━━<br/>CLI: score X vs Y<br/>calls spectral_init::trustworthiness"]
        BIN_PROF["src/bin/tw_profiler.rs<br/>━━━━━━━━━━<br/>Timing harness for<br/>trustworthiness kernel"]
        BENCH["benches/<br/>trustworthiness_bench.rs<br/>dist_sq_bench.rs<br/>━━━━━━━━━━<br/>Criterion micro-benches"]
        ITESTS["tests/integration/<br/>━━━━━━━━━━<br/>test_trustworthiness<br/>test_accuracy_report<br/>test_simd_lobpcg_parity<br/>test_exp_rsvd_nbiter_sweep"]
    end

    subgraph Layer2 ["LAYER 2 — CRATE ROOT (public API surface)"]
        direction LR
        LIB["● src/lib.rs<br/>━━━━━━━━━━<br/>pub fn spectral_init()<br/>Re-exports (feature-gated):<br/>trustworthiness<br/>trustworthiness_subsampled"]
    end

    subgraph Layer1 ["LAYER 1 — FEATURE MODULES"]
        direction TB

        subgraph MetricsBox ["metrics layer (high fan-in)"]
            METRICS["● src/metrics.rs<br/>━━━━━━━━━━<br/>Thresholds: RSVD/LOBPCG/SINV/PSD<br/>eigenpair_residual, orthogonality<br/>spectral_gap, eigenvalue_bounds<br/>trustworthiness<br/>+ trustworthiness_subsampled<br/>+ trustworthiness_inner (shared)"]
        end

        subgraph SolverBox ["solvers/ (eigensolver escalation chain)"]
            direction LR
            SOLV_MOD["solvers/mod.rs<br/>━━━━━━━━━━<br/>6-level escalation<br/>enforce_psd_contract"]
            SOLV_DENSE["solvers/dense.rs"]
            SOLV_LOBPCG["solvers/lobpcg.rs"]
            SOLV_SINV["solvers/sinv.rs"]
            SOLV_RSVD["solvers/rsvd.rs"]
        end

        subgraph AlgoBox ["algorithmic modules"]
            direction LR
            OP["operator.rs<br/>━━━━━━━━━━<br/>Laplacian matvec<br/>(AVX2 kernel)"]
            LAP["laplacian.rs<br/>━━━━━━━━━━<br/>Build L = I − D^-½ W D^-½"]
            COMP["components.rs<br/>━━━━━━━━━━<br/>Connected components BFS"]
            MCOMP["multi_component.rs<br/>━━━━━━━━━━<br/>Disconnected graph handling"]
            SCAL["scaling.rs<br/>━━━━━━━━━━<br/>Coordinate scaling + noise"]
            SEL["selection.rs<br/>━━━━━━━━━━<br/>Eigenvector selection"]
            CFG["config.rs<br/>━━━━━━━━━━<br/>SpectralInitConfig<br/>ComputeMode"]
        end
    end

    subgraph Layer0 ["LAYER 0 — EXTERNAL CRATES"]
        direction LR
        EXT_FAER["faer<br/>━━━━━━━━━━<br/>Dense EVD, linalg"]
        EXT_NDARR["ndarray<br/>━━━━━━━━━━<br/>Dense arrays"]
        EXT_SPRS["sprs<br/>━━━━━━━━━━<br/>CsMatI sparse"]
        EXT_RAYON["rayon<br/>━━━━━━━━━━<br/>par_iter"]
        EXT_RAND["rand<br/>━━━━━━━━━━<br/>SmallRng, index::sample"]
        EXT_LINFA["linfa-linalg<br/>━━━━━━━━━━<br/>LOBPCG"]
    end

    %% LAYER 3 → LAYER 2 (clients depend on public API only) %%
    BIN_TW -->|"spectral_init::trustworthiness"| LIB
    BIN_PROF -->|"trustworthiness"| LIB
    BENCH -->|"trustworthiness"| LIB
    ITESTS -->|"spectral_init::{metrics, spectral_init, ...}"| LIB

    %% LAYER 2 → LAYER 1 (re-exports and public API wiring) %%
    LIB -->|"pub use (cfg: testing/cli)"| METRICS
    LIB --> SOLV_MOD
    LIB --> LAP
    LIB --> COMP
    LIB --> MCOMP
    LIB --> SCAL
    LIB --> SEL
    LIB --> CFG
    LIB --> OP

    %% LAYER 1 intra-layer: fan-in into metrics %%
    SOLV_MOD -->|"thresholds, residuals"| METRICS
    SOLV_LOBPCG -->|"LOBPCG_*_THRESHOLD"| METRICS
    SOLV_SINV -->|"SINV_*_THRESHOLD"| METRICS
    OP -->|"residual helpers"| METRICS

    %% LAYER 1 intra-layer: solver chain wiring %%
    SOLV_MOD --> SOLV_DENSE
    SOLV_MOD --> SOLV_LOBPCG
    SOLV_MOD --> SOLV_SINV
    SOLV_MOD --> SOLV_RSVD
    SOLV_LOBPCG --> OP
    SOLV_SINV --> OP

    %% LAYER 1 → LAYER 0 (external deps, grouped) %%
    METRICS --> EXT_FAER
    METRICS --> EXT_NDARR
    METRICS --> EXT_SPRS
    METRICS --> EXT_RAYON
    METRICS -->|"NEW path:<br/>seq::index::sample"| EXT_RAND
    SOLV_LOBPCG --> EXT_LINFA
    SOLV_SINV --> EXT_LINFA
    SOLV_DENSE --> EXT_FAER
    SOLV_RSVD --> EXT_FAER
    LAP --> EXT_SPRS
    LAP --> EXT_NDARR
    OP --> EXT_SPRS
    OP --> EXT_NDARR
    SCAL --> EXT_RAND
    SCAL --> EXT_NDARR

    %% CLASS ASSIGNMENTS %%
    class BIN_TW,BIN_PROF,BENCH,ITESTS cli;
    class LIB phase;
    class METRICS stateNode;
    class SOLV_MOD,SOLV_DENSE,SOLV_LOBPCG,SOLV_SINV,SOLV_RSVD,OP,LAP,COMP,MCOMP,SCAL,SEL,CFG handler;
    class EXT_FAER,EXT_NDARR,EXT_SPRS,EXT_RAYON,EXT_RAND,EXT_LINFA integration;
```

Closes #265

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260410-201325-840122/.autoskillit/temp/make-plan/ship_trustworthiness_subsampled_plan_2026-04-10_201500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 194 | 16.9k | 777.7k | 79.4k | 1 | 4m 27s |
| verify | 130 | 11.1k | 571.2k | 55.2k | 1 | 3m 6s |
| implement | 285 | 19.5k | 1.6M | 102.1k | 1 | 8m 22s |
| prepare_pr | 50 | 2.8k | 110.6k | 27.0k | 1 | 47s |
| run_arch_lenses | 174 | 9.4k | 579.3k | 36.9k | 1 | 2m 21s |
| compose_pr | 59 | 4.9k | 143.2k | 23.1k | 1 | 1m 17s |
| **Total** | 892 | 64.5k | 3.8M | 323.7k | | 20m 23s |